### PR TITLE
Add trigger to run e2e tests through PR

### DIFF
--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -85,4 +85,4 @@ jobs:
         if: ${{ steps.check-membership.outputs.ok == 'true' && steps.action.outputs.action == 'test' }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh workflow run e2e.yaml --ref "${{ steps.pr_info.outputs.base_ref_name }}" -R ${{ github.repository }} -f pr_id=${{ github.event.issue.number }}
+        run: gh workflow run e2e.yaml --ref "${{ steps.pr_info.outputs.base_ref_name }}" -R ${{ github.repository }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,13 +1,7 @@
 name: Run E2E tests
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_id:
-        type: string
-        description: The ID of the PR to report failed tests to.
-        required: false
-        default: ""
+  workflow_dispatch: {}
 
 defaults:
   run:
@@ -138,23 +132,13 @@ jobs:
         run: exit 0
 
       - name: Generate Token
-        if: ${{ inputs.pr_id != '' }}
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.WORKFLOW_AUTH_APP_ID }}
           private-key: ${{ secrets.WORKFLOW_AUTH_PRIVATE_KEY }}
 
-      - name: Failing run
-        if: ${{ inputs.pr_id != '' && contains(needs.*.result, 'failure') }}
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh pr comment ${{ inputs.pr_id }} --body "E2E tests failed. See [details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." -R ${{ github.repository }}
-          exit 1
-
       - name: Send status check
-        if: ${{ inputs.pr_id != '' }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |


### PR DESCRIPTION
Allow running e2e tests using a "/test" comment in the PR and ship e2e test result to the PR

This allows requiring e2e tests to pass before merging