### PR TITLE
Lazy client

### DIFF
--- a/pkg/provider/model.go
+++ b/pkg/provider/model.go
@@ -8,12 +8,12 @@ import (
 type Model struct {
 	Protocol   types.String `tfsdk:"protocol"`
 	Host       types.String `tfsdk:"host"`
-	Port       types.Number `tfsdk:"port"`
+	Port       types.Int32  `tfsdk:"port"`
 	AuthConfig AuthConfig   `tfsdk:"auth_config"`
 }
 
 type AuthConfig struct {
-	Strategy string  `tfsdk:"strategy"`
-	Username string  `tfsdk:"username"`
-	Password *string `tfsdk:"password"`
+	Strategy types.String `tfsdk:"strategy"`
+	Username types.String `tfsdk:"username"`
+	Password types.String `tfsdk:"password"`
 }

--- a/pkg/provider/model.go
+++ b/pkg/provider/model.go
@@ -1,11 +1,15 @@
 package provider
 
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
 // Model describes the provider data model.
 type Model struct {
-	Protocol   string     `tfsdk:"protocol"`
-	Host       string     `tfsdk:"host"`
-	Port       uint16     `tfsdk:"port"`
-	AuthConfig AuthConfig `tfsdk:"auth_config"`
+	Protocol   types.String `tfsdk:"protocol"`
+	Host       types.String `tfsdk:"host"`
+	Port       types.Number `tfsdk:"port"`
+	AuthConfig AuthConfig   `tfsdk:"auth_config"`
 }
 
 type AuthConfig struct {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -123,7 +123,10 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			case authStrategyPassword:
 				auth = &clickhouseclient.UserPasswordAuth{
 					Username: data.AuthConfig.Username.ValueString(),
-					Password: *data.AuthConfig.Password.ValueStringPointer(),
+				}
+
+				if !data.AuthConfig.Password.IsNull() {
+					auth.Password = data.AuthConfig.Password.ValueString()
 				}
 
 				valid, errorStrings := auth.ValidateConfig()
@@ -162,7 +165,10 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			case authStrategyBasicAuth:
 				auth = &clickhouseclient.BasicAuth{
 					Username: data.AuthConfig.Username.ValueString(),
-					Password: *data.AuthConfig.Password.ValueStringPointer(),
+				}
+
+				if !data.AuthConfig.Password.IsNull() {
+					auth.Password = data.AuthConfig.Password.ValueString()
 				}
 
 				valid, errorStrings := auth.ValidateConfig()


### PR DESCRIPTION
Use terraform data types in the provider's model in order to lazy load them and thus support dependencies between this provider and the clickhouse cloud provider