### PR TITLE
Add query builder support for SETTINGS PROFILE

### DIFF
--- a/internal/dbops/interface.go
+++ b/internal/dbops/interface.go
@@ -29,5 +29,9 @@ type Client interface {
 	RevokeGrantPrivilege(ctx context.Context, accessType string, database *string, table *string, column *string, granteeUserName *string, granteeRoleName *string, clusterName *string) error
 	GetAllGrantsForGrantee(ctx context.Context, granteeUsername *string, granteeRoleName *string, clusterName *string) ([]GrantPrivilege, error)
 
+	CreateSettingsProfile(ctx context.Context, profile SettingsProfile, clusterName *string) (*SettingsProfile, error)
+	GetSettingsProfile(ctx context.Context, name string, clusterName *string) (*SettingsProfile, error)
+	DeleteSettingsProfile(ctx context.Context, name string, clusterName *string) error
+
 	IsReplicatedStorage(ctx context.Context) (bool, error)
 }

--- a/internal/dbops/settingsprofile.go
+++ b/internal/dbops/settingsprofile.go
@@ -31,12 +31,7 @@ func (i *impl) CreateSettingsProfile(ctx context.Context, profile SettingsProfil
 		WithInheritProfile(profile.InheritProfile)
 
 	for _, setting := range profile.Settings {
-		var writability *string
-		if setting.Writability != nil {
-			val := string(*setting.Writability)
-			writability = &val
-		}
-		builder.AddSetting(setting.Name, setting.Value, setting.Min, setting.Max, writability)
+		builder.AddSetting(setting.Name, setting.Value, setting.Min, setting.Max, setting.Writability)
 	}
 
 	sql, err := builder.Build()

--- a/internal/dbops/settingsprofile.go
+++ b/internal/dbops/settingsprofile.go
@@ -1,0 +1,172 @@
+package dbops
+
+import (
+	"context"
+
+	"github.com/pingcap/errors"
+
+	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/clickhouseclient"
+	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/querybuilder"
+)
+
+type Setting struct {
+	Name        string
+	Value       *string
+	Min         *string
+	Max         *string
+	Writability *string
+}
+
+type SettingsProfile struct {
+	Name string `json:"name"`
+
+	InheritProfile *string
+	Settings       []Setting
+}
+
+func (i *impl) CreateSettingsProfile(ctx context.Context, profile SettingsProfile, clusterName *string) (*SettingsProfile, error) {
+	builder := querybuilder.
+		NewCreateSettingsProfile(profile.Name).
+		WithCluster(clusterName).
+		WithInheritProfile(profile.InheritProfile)
+
+	for _, setting := range profile.Settings {
+		var writability *string
+		if setting.Writability != nil {
+			val := string(*setting.Writability)
+			writability = &val
+		}
+		builder.AddSetting(setting.Name, setting.Value, setting.Min, setting.Max, writability)
+	}
+
+	sql, err := builder.Build()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error building query")
+	}
+
+	err = i.clickhouseClient.Exec(ctx, sql)
+	if err != nil {
+		return nil, errors.WithMessage(err, "error running query")
+	}
+
+	return i.GetSettingsProfile(ctx, profile.Name, clusterName)
+}
+
+func (i *impl) GetSettingsProfile(ctx context.Context, name string, clusterName *string) (*SettingsProfile, error) {
+	sql, err := querybuilder.
+		NewSelect(
+			[]querybuilder.Field{
+				querybuilder.NewField("profile_name"),
+				querybuilder.NewField("setting_name"),
+				querybuilder.NewField("value"),
+				querybuilder.NewField("min"),
+				querybuilder.NewField("max"),
+				querybuilder.NewField("writability"),
+				querybuilder.NewField("inherit_profile"),
+			},
+			"system.settings_profile_elements",
+		).
+		WithCluster(clusterName).
+		Where(querybuilder.WhereEquals("profile_name", name)).
+		OrderBy(querybuilder.NewField("index"), querybuilder.ASC).
+		Build()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error building query")
+	}
+
+	var profile *SettingsProfile
+
+	err = i.clickhouseClient.Select(ctx, sql, func(data clickhouseclient.Row) error {
+		n, err := data.GetNullableString("profile_name")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'profile_name' field")
+		}
+
+		settingName, err := data.GetNullableString("setting_name")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'setting_name' field")
+		}
+
+		value, err := data.GetNullableString("value")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'value' field")
+		}
+
+		minVal, err := data.GetNullableString("min")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'min' field")
+		}
+
+		maxVal, err := data.GetNullableString("max")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'max' field")
+		}
+
+		writability, err := data.GetNullableString("writability")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'writability' field")
+		}
+
+		inherit, err := data.GetNullableString("inherit_profile")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'inherit_profile' field")
+		}
+
+		if profile == nil {
+			profile = &SettingsProfile{
+				Name:     *n,
+				Settings: make([]Setting, 0),
+			}
+		}
+
+		if inherit != nil {
+			profile.InheritProfile = inherit
+		}
+
+		if settingName != nil {
+			profile.Settings = append(profile.Settings, Setting{
+				Name:        *settingName,
+				Value:       value,
+				Min:         minVal,
+				Max:         maxVal,
+				Writability: writability,
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithMessage(err, "error running query")
+	}
+
+	if profile == nil {
+		// SettingsProfile not found
+		return nil, nil
+	}
+
+	return profile, nil
+}
+
+func (i *impl) DeleteSettingsProfile(ctx context.Context, name string, clusterName *string) error {
+	profile, err := i.GetSettingsProfile(ctx, name, clusterName)
+	if err != nil {
+		return errors.WithMessage(err, "error getting database name")
+	}
+
+	if profile == nil {
+		// This is desired state.
+		return nil
+	}
+
+	sql, err := querybuilder.NewDropSettingsProfile(profile.Name).WithCluster(clusterName).Build()
+	if err != nil {
+		return errors.WithMessage(err, "error building query")
+	}
+
+	err = i.clickhouseClient.Exec(ctx, sql)
+	if err != nil {
+		return errors.WithMessage(err, "error running query")
+	}
+
+	return nil
+}

--- a/internal/querybuilder/createdrop.go
+++ b/internal/querybuilder/createdrop.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	resourceTypeDatabase = "DATABASE"
-	resourceTypeRole     = "ROLE"
-	resourceTypeUser     = "USER"
+	resourceTypeDatabase        = "DATABASE"
+	resourceTypeRole            = "ROLE"
+	resourceTypeUser            = "USER"
+	resourceTypeSettingsProfile = "SETTINGS PROFILE"
 
 	actionCreate = "CREATE"
 	actionDrop   = "DROP"
@@ -41,6 +42,10 @@ func NewDropDatabase(resourceName string) CreateDropQueryBuilder {
 
 func NewDropUser(resourceName string) CreateDropQueryBuilder {
 	return newDrop(resourceTypeUser, resourceName)
+}
+
+func NewDropSettingsProfile(resourceName string) CreateDropQueryBuilder {
+	return newDrop(resourceTypeSettingsProfile, resourceName)
 }
 
 func (q *createDropQueryBuilder) WithCluster(clusterName *string) CreateDropQueryBuilder {

--- a/internal/querybuilder/createsettingsprofile.go
+++ b/internal/querybuilder/createsettingsprofile.go
@@ -1,0 +1,88 @@
+package querybuilder
+
+import (
+	"strings"
+
+	"github.com/pingcap/errors"
+)
+
+// CreateSettingsProfileQueryBuilder is an interface to build CREATE SETTINGS PROFILE SQL queries (already interpolated).
+type CreateSettingsProfileQueryBuilder interface {
+	QueryBuilder
+	WithInheritProfile(profileName *string) CreateSettingsProfileQueryBuilder
+	WithCluster(clusterName *string) CreateSettingsProfileQueryBuilder
+	AddSetting(name string, value *string, min *string, max *string, writability *string) CreateSettingsProfileQueryBuilder
+}
+
+type createSettingsProfileQueryBuilder struct {
+	profileName    string
+	clusterName    *string
+	inheritProfile *string
+	settings       []setting
+}
+
+func NewCreateSettingsProfile(name string) CreateSettingsProfileQueryBuilder {
+	return &createSettingsProfileQueryBuilder{
+		profileName: name,
+		settings:    make([]setting, 0),
+	}
+}
+
+func (q *createSettingsProfileQueryBuilder) WithCluster(clusterName *string) CreateSettingsProfileQueryBuilder {
+	q.clusterName = clusterName
+	return q
+}
+
+func (q *createSettingsProfileQueryBuilder) WithInheritProfile(profileName *string) CreateSettingsProfileQueryBuilder {
+	q.inheritProfile = profileName
+	return q
+}
+
+func (q *createSettingsProfileQueryBuilder) AddSetting(name string, value *string, min *string, max *string, writability *string) CreateSettingsProfileQueryBuilder {
+	q.settings = append(q.settings, &settingData{
+		Name:        name,
+		Value:       value,
+		Min:         min,
+		Max:         max,
+		Writability: writability,
+	})
+	return q
+}
+
+func (q *createSettingsProfileQueryBuilder) Build() (string, error) {
+	if q.profileName == "" {
+		return "", errors.New("profileName cannot be empty for CREATE SETTINGS PROFILE queries")
+	}
+
+	tokens := []string{
+		"CREATE",
+		"SETTINGS PROFILE",
+		backtick(q.profileName),
+	}
+	if q.clusterName != nil {
+		tokens = append(tokens, "ON", "CLUSTER", quote(*q.clusterName))
+	}
+
+	if len(q.settings) == 0 {
+		return "", errors.New("cannot create settings profile with no settings")
+	}
+
+	tokens = append(tokens, "SETTINGS")
+
+	renderedSettings := make([]string, 0)
+	for _, s := range q.settings {
+		def, err := s.SQLDef()
+		if err != nil {
+			return "", errors.WithMessage(err, "Error building query")
+		}
+		renderedSettings = append(renderedSettings, def)
+	}
+
+	tokens = append(tokens, strings.Join(renderedSettings, ", "))
+
+	if q.inheritProfile != nil {
+		tokens = append(tokens, "INHERIT", quote(*q.inheritProfile))
+	}
+
+	return strings.Join(tokens, " ") + ";", nil
+}

--- a/internal/querybuilder/createsettingsprofile_test.go
+++ b/internal/querybuilder/createsettingsprofile_test.go
@@ -1,0 +1,100 @@
+package querybuilder
+
+import (
+	"testing"
+)
+
+func Test_createSettingsProfileQueryBuilder_Build(t *testing.T) {
+	type fields struct {
+	}
+	tests := []struct {
+		name        string
+		profileName string
+		clusterName *string
+		inherit     *string
+		settings    []setting
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "Single setting",
+			profileName: "prf1",
+			clusterName: nil,
+			settings:    []setting{newSettingMock("mock_rendered_setting")},
+			want:        "CREATE SETTINGS PROFILE `prf1` SETTINGS mock_rendered_setting;",
+			wantErr:     false,
+		},
+		{
+			name:        "Multiple settings",
+			profileName: "prf1",
+			clusterName: nil,
+			settings:    []setting{newSettingMock("mock_rendered_setting1"), newSettingMock("mock_rendered_setting2")},
+			want:        "CREATE SETTINGS PROFILE `prf1` SETTINGS mock_rendered_setting1, mock_rendered_setting2;",
+			wantErr:     false,
+		},
+		{
+			name:        "No settings",
+			profileName: "prf1",
+			clusterName: nil,
+			settings:    nil,
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:        "on cluster",
+			profileName: "prf1",
+			clusterName: strPtr("cluster1"),
+			settings:    []setting{newSettingMock("mock_rendered_setting")},
+			want:        "CREATE SETTINGS PROFILE `prf1` ON CLUSTER 'cluster1' SETTINGS mock_rendered_setting;",
+			wantErr:     false,
+		},
+		{
+			name:        "Inherit",
+			profileName: "prf1",
+			clusterName: nil,
+			inherit:     strPtr("default"),
+			settings:    []setting{newSettingMock("mock_rendered_setting")},
+			want:        "CREATE SETTINGS PROFILE `prf1` SETTINGS mock_rendered_setting INHERIT 'default';",
+			wantErr:     false,
+		},
+		{
+			name:        "Inherit with quote",
+			profileName: "prf1",
+			clusterName: nil,
+			inherit:     strPtr("def'ault"),
+			settings:    []setting{newSettingMock("mock_rendered_setting")},
+			want:        "CREATE SETTINGS PROFILE `prf1` SETTINGS mock_rendered_setting INHERIT 'def\\'ault';",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &createSettingsProfileQueryBuilder{
+				profileName:    tt.profileName,
+				clusterName:    tt.clusterName,
+				inheritProfile: tt.inherit,
+				settings:       tt.settings,
+			}
+			got, err := q.Build()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Build() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type settingsMock struct {
+	rendered string
+}
+
+func newSettingMock(rendered string) setting {
+	return &settingsMock{rendered: rendered}
+}
+
+func (s *settingsMock) SQLDef() (string, error) {
+	return s.rendered, nil
+}

--- a/internal/querybuilder/createsettingsprofile_test.go
+++ b/internal/querybuilder/createsettingsprofile_test.go
@@ -5,8 +5,7 @@ import (
 )
 
 func Test_createSettingsProfileQueryBuilder_Build(t *testing.T) {
-	type fields struct {
-	}
+	type fields struct{}
 	tests := []struct {
 		name        string
 		profileName string

--- a/internal/querybuilder/createsettingsprofile_test.go
+++ b/internal/querybuilder/createsettingsprofile_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func Test_createSettingsProfileQueryBuilder_Build(t *testing.T) {
-	type fields struct{}
 	tests := []struct {
 		name        string
 		profileName string

--- a/internal/querybuilder/select_test.go
+++ b/internal/querybuilder/select_test.go
@@ -5,14 +5,19 @@ import (
 )
 
 func Test_selectQueryBuilder_Build(t *testing.T) {
+	orderBy := NewField("col1")
+	orderDirection := ASC
+
 	tests := []struct {
-		name    string
-		fields  []Field
-		where   []Where
-		from    string
-		cluster string
-		want    string
-		wantErr bool
+		name     string
+		fields   []Field
+		where    []Where
+		from     string
+		cluster  string
+		orderCol *Field
+		orderDir *OrderDirection
+		want     string
+		wantErr  bool
 	}{
 		{
 			name:    "Select one with",
@@ -59,6 +64,16 @@ func Test_selectQueryBuilder_Build(t *testing.T) {
 			want:    "SELECT `name` FROM `users` WHERE (mock_where_clause AND mock_where_clause_2);",
 			wantErr: false,
 		},
+		{
+			name:     "Select with order by",
+			fields:   []Field{NewField("name")},
+			where:    []Where{whereMock{"mock_where_clause"}},
+			orderCol: &orderBy,
+			orderDir: &orderDirection,
+			from:     "users",
+			want:     "SELECT `name` FROM `users` WHERE (mock_where_clause) ORDER BY `col1` ASC;",
+			wantErr:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,6 +83,9 @@ func Test_selectQueryBuilder_Build(t *testing.T) {
 			}
 			if tt.cluster != "" {
 				q = q.WithCluster(&tt.cluster)
+			}
+			if tt.orderCol != nil && tt.orderDir != nil {
+				q = q.OrderBy(*tt.orderCol, *tt.orderDir)
 			}
 			got, err := q.Build()
 			if (err != nil) != tt.wantErr {

--- a/internal/querybuilder/setting.go
+++ b/internal/querybuilder/setting.go
@@ -1,9 +1,16 @@
 package querybuilder
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pingcap/errors"
+)
+
+const (
+	writabilityConst      = "CONST"
+	writabilityWritable   = "WRITABLE"
+	writabilityChangeable = "CHANGEABLE_IN_READONLY"
 )
 
 type settingData struct {
@@ -25,6 +32,10 @@ func (s *settingData) SQLDef() (string, error) {
 
 	if s.Value == nil && s.Min == nil && s.Max == nil {
 		return "", errors.New("Either Value, Min or Max should be set")
+	}
+
+	if s.Writability != nil && *s.Writability != writabilityConst && *s.Writability != writabilityWritable && *s.Writability != writabilityChangeable {
+		return "", errors.New(fmt.Sprintf("Invalid value for Writability. Can be %q, %q or %q", writabilityConst, writabilityWritable, writabilityChangeable))
 	}
 
 	singleSetting := make([]string, 0)

--- a/internal/querybuilder/setting.go
+++ b/internal/querybuilder/setting.go
@@ -1,0 +1,46 @@
+package querybuilder
+
+import (
+	"strings"
+
+	"github.com/pingcap/errors"
+)
+
+type settingData struct {
+	Name        string
+	Value       *string
+	Min         *string
+	Max         *string
+	Writability *string
+}
+
+type setting interface {
+	SQLDef() (string, error)
+}
+
+func (s *settingData) SQLDef() (string, error) {
+	if s.Name == "" {
+		return "", errors.New("Name can't be empty")
+	}
+
+	if s.Value == nil && s.Min == nil && s.Max == nil {
+		return "", errors.New("Either Value, Min or Max should be set")
+	}
+
+	singleSetting := make([]string, 0)
+	singleSetting = append(singleSetting, s.Name)
+	if s.Value != nil {
+		singleSetting = append(singleSetting, "=", quote(*s.Value))
+	}
+	if s.Min != nil {
+		singleSetting = append(singleSetting, "MIN", quote(*s.Min))
+	}
+	if s.Max != nil {
+		singleSetting = append(singleSetting, "MAX", quote(*s.Max))
+	}
+	if s.Writability != nil {
+		singleSetting = append(singleSetting, *s.Writability)
+	}
+
+	return strings.Join(singleSetting, " "), nil
+}

--- a/internal/querybuilder/setting_test.go
+++ b/internal/querybuilder/setting_test.go
@@ -1,0 +1,94 @@
+package querybuilder
+
+import (
+	"testing"
+)
+
+func Test_setting_SQLDef(t *testing.T) {
+	tests := []struct {
+		name    string
+		setting setting
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Empty name",
+			setting: &settingData{
+				Name: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "No values",
+			setting: &settingData{
+				Name: "test",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Only value",
+			setting: &settingData{
+				Name:  "test",
+				Value: strPtr("123"),
+			},
+			want:    "test = '123'",
+			wantErr: false,
+		},
+		{
+			name: "Only min",
+			setting: &settingData{
+				Name: "test",
+				Min:  strPtr("456"),
+			},
+			want:    "test MIN '456'",
+			wantErr: false,
+		},
+		{
+			name: "Only max",
+			setting: &settingData{
+				Name: "test",
+				Max:  strPtr("789"),
+			},
+			want:    "test MAX '789'",
+			wantErr: false,
+		},
+		{
+			name: "Only min and max",
+			setting: &settingData{
+				Name: "test",
+				Min:  strPtr("10"),
+				Max:  strPtr("100"),
+			},
+			want:    "test MIN '10' MAX '100'",
+			wantErr: false,
+		},
+		{
+			name: "Value, min and max",
+			setting: &settingData{
+				Name:  "test",
+				Value: strPtr("50"),
+				Min:   strPtr("10"),
+				Max:   strPtr("100"),
+			},
+			want:    "test = '50' MIN '10' MAX '100'",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.setting.SQLDef()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SQLDef() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SQLDef() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func strPtr(val string) *string {
+	return &val
+}

--- a/internal/querybuilder/setting_test.go
+++ b/internal/querybuilder/setting_test.go
@@ -89,6 +89,7 @@ func Test_setting_SQLDef(t *testing.T) {
 		})
 	}
 }
+
 func strPtr(val string) *string {
 	return &val
 }


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/sre/issues/448

first of a list of PRs to add support for SETTINGS PROFILES to this TF provider.
This PR adds query builder and dbops interfaces' support for those objects.