### PR TITLE
Allow to change role's settings profile

### DIFF
--- a/examples/tests/settingsprofile/main.tf
+++ b/examples/tests/settingsprofile/main.tf
@@ -12,15 +12,11 @@ resource "clickhousedbops_settingsprofile" "profile1" {
       writability = "CHANGEABLE_IN_READONLY"
     },
     {
-      name = "max_threads"
-      value = "1000"
-      min = "100"
-      max = "2000"
-      writability = "CONST"
+      name = "network_compression_method"
+      value = "LZ4"
     },
   ]
 }
-
 
 resource "clickhousedbops_role" "tester" {
   cluster_name = var.cluster_name
@@ -29,11 +25,11 @@ resource "clickhousedbops_role" "tester" {
   settings_profile = clickhousedbops_settingsprofile.profile1.name
 }
 
-resource "clickhousedbops_user" "john" {
-  cluster_name = var.cluster_name
-  name = "john"
-  password_sha256_hash_wo = sha256("test")
-  password_sha256_hash_wo_version = 1
-
-  settings_profile = clickhousedbops_settingsprofile.profile1.name
-}
+# resource "clickhousedbops_user" "john" {
+#   cluster_name = var.cluster_name
+#   name = "john"
+#   password_sha256_hash_wo = sha256("test")
+#   password_sha256_hash_wo_version = 1
+#
+#   settings_profile = clickhousedbops_settingsprofile.profile1.name
+# }

--- a/internal/dbops/interface.go
+++ b/internal/dbops/interface.go
@@ -14,6 +14,7 @@ type Client interface {
 	GetRole(ctx context.Context, id string, clusterName *string) (*Role, error)
 	DeleteRole(ctx context.Context, id string, clusterName *string) error
 	FindRoleByName(ctx context.Context, name string, clusterName *string) (*Role, error)
+	UpdateRole(ctx context.Context, role Role, clusterName *string) (*Role, error)
 
 	CreateUser(ctx context.Context, user User, clusterName *string) (*User, error)
 	GetUser(ctx context.Context, id string, clusterName *string) (*User, error)

--- a/internal/dbops/role.go
+++ b/internal/dbops/role.go
@@ -142,3 +142,27 @@ func (i *impl) FindRoleByName(ctx context.Context, name string, clusterName *str
 
 	return i.GetRole(ctx, uuid, clusterName)
 }
+
+func (i *impl) UpdateRole(ctx context.Context, role Role, clusterName *string) (*Role, error) {
+	// Retrieve current role
+	existing, err := i.GetRole(ctx, role.ID, clusterName)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Unable to get existing role")
+	}
+
+	sql, err := querybuilder.
+		NewAlterRole(existing.Name).
+		WithCluster(clusterName).
+		ChangeSettingProfile(existing.SettingsProfile, role.SettingsProfile).
+		Build()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error building query")
+	}
+
+	err = i.clickhouseClient.Exec(ctx, sql)
+	if err != nil {
+		return nil, errors.WithMessage(err, "error running query")
+	}
+
+	return i.GetRole(ctx, role.ID, clusterName)
+}

--- a/internal/querybuilder/alterrole.go
+++ b/internal/querybuilder/alterrole.go
@@ -1,0 +1,66 @@
+package querybuilder
+
+import (
+	"strings"
+
+	"github.com/pingcap/errors"
+)
+
+// AlterRoleQueryBuilder is an interface to build ALTER ROLE SQL queries (already interpolated).
+type AlterRoleQueryBuilder interface {
+	QueryBuilder
+	ChangeSettingProfile(oldProfileName *string, newProfileName *string) AlterRoleQueryBuilder
+	WithCluster(clusterName *string) AlterRoleQueryBuilder
+}
+
+type alterRoleQueryBuilder struct {
+	resourceName       string
+	oldSettingsProfile *string
+	newSettingsProfile *string
+	clusterName        *string
+}
+
+func NewAlterRole(resourceName string) AlterRoleQueryBuilder {
+	return &alterRoleQueryBuilder{
+		resourceName: resourceName,
+	}
+}
+
+func (q *alterRoleQueryBuilder) ChangeSettingProfile(oldProfileName *string, newProfileName *string) AlterRoleQueryBuilder {
+	q.oldSettingsProfile = oldProfileName
+	q.newSettingsProfile = newProfileName
+	return q
+}
+
+func (q *alterRoleQueryBuilder) WithCluster(clusterName *string) AlterRoleQueryBuilder {
+	q.clusterName = clusterName
+	return q
+}
+
+func (q *alterRoleQueryBuilder) Build() (string, error) {
+	if q.resourceName == "" {
+		return "", errors.New("resourceName cannot be empty for ALTER ROLE queries")
+	}
+
+	if (q.oldSettingsProfile == nil && q.newSettingsProfile == nil) ||
+		(q.oldSettingsProfile != nil && q.newSettingsProfile != nil && *q.oldSettingsProfile == *q.newSettingsProfile) {
+		return "", errors.New("no change to be made")
+	}
+
+	tokens := []string{
+		"ALTER",
+		"ROLE",
+		backtick(q.resourceName),
+	}
+	if q.clusterName != nil {
+		tokens = append(tokens, "ON", "CLUSTER", quote(*q.clusterName))
+	}
+	if q.oldSettingsProfile != nil {
+		tokens = append(tokens, "DROP", "PROFILES", quote(*q.oldSettingsProfile))
+	}
+	if q.newSettingsProfile != nil {
+		tokens = append(tokens, "ADD", "PROFILE", quote(*q.newSettingsProfile))
+	}
+
+	return strings.Join(tokens, " ") + ";", nil
+}

--- a/internal/querybuilder/alterrole_test.go
+++ b/internal/querybuilder/alterrole_test.go
@@ -1,0 +1,75 @@
+package querybuilder
+
+import (
+	"testing"
+)
+
+func Test_alterRoleQueryBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldSettingsProfile *string
+		newSettingsProfile *string
+		clusterName        *string
+		want               string
+		wantErr            bool
+	}{
+		{
+			name:               "Add profile",
+			newSettingsProfile: strPtr("profile1"),
+			want:               "ALTER ROLE `foo` ADD PROFILE 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:               "Replace profile",
+			newSettingsProfile: strPtr("profile1"),
+			oldSettingsProfile: strPtr("old"),
+			want:               "ALTER ROLE `foo` DROP PROFILES 'old' ADD PROFILE 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:               "Add profile on cluster",
+			newSettingsProfile: strPtr("profile1"),
+			clusterName:        strPtr("cluster1"),
+			want:               "ALTER ROLE `foo` ON CLUSTER 'cluster1' ADD PROFILE 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:               "Replace profile on cluster",
+			newSettingsProfile: strPtr("profile1"),
+			oldSettingsProfile: strPtr("old"),
+			clusterName:        strPtr("cluster1"),
+			want:               "ALTER ROLE `foo` ON CLUSTER 'cluster1' DROP PROFILES 'old' ADD PROFILE 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:    "No profile set",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:               "Same profile set",
+			newSettingsProfile: strPtr("profile1"),
+			oldSettingsProfile: strPtr("profile1"),
+			want:               "",
+			wantErr:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &alterRoleQueryBuilder{
+				resourceName:       "foo",
+				oldSettingsProfile: tt.oldSettingsProfile,
+				newSettingsProfile: tt.newSettingsProfile,
+				clusterName:        tt.clusterName,
+			}
+			got, err := q.Build()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Build() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resource/role/role.go
+++ b/pkg/resource/role/role.go
@@ -63,9 +63,6 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"settings_profile": schema.StringAttribute{
 				Optional:    true,
 				Description: "Name of the settings profile to assign to the role",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 		},
 		MarkdownDescription: roleResourceDescription,
@@ -175,7 +172,45 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 }
 
 func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	panic("Update of role resource is not supported")
+	var plan, state Role
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only field we allow to change is the settings profile.
+	{
+		planValue := plan.SettingsProfile.ValueStringPointer()
+		stateValue := state.SettingsProfile.ValueStringPointer()
+
+		if planValue == nil && stateValue != nil ||
+			planValue != nil && stateValue == nil ||
+			(planValue != nil && stateValue != nil && *planValue != *stateValue) {
+			// Settings profile is changed.
+			role, err := r.client.UpdateRole(ctx, dbops.Role{
+				ID:              state.ID.ValueString(),
+				SettingsProfile: plan.SettingsProfile.ValueStringPointer(),
+			}, plan.ClusterName.ValueStringPointer())
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Updating ClickHouse Role",
+					fmt.Sprintf("%+v\n", err),
+				)
+				return
+			}
+
+			state.SettingsProfile = types.StringPointerValue(role.SettingsProfile)
+			diags = resp.State.Set(ctx, &state)
+			resp.Diagnostics.Append(diags...)
+		}
+	}
 }
 
 func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/sre/issues/448

When we change the settings profile of a role, we want to avoid recreating the role as it's too disruptive operation (for example it causes the role grants to be lost).

This PR adds support to change settings profile on a role