### PR TITLE
Allow to change users's settings profile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
     - typecheck
     - gosec
     - unconvert
-    - dupl
     - goconst
     - goimports
     - copyloopvar

--- a/internal/dbops/interface.go
+++ b/internal/dbops/interface.go
@@ -20,6 +20,7 @@ type Client interface {
 	GetUser(ctx context.Context, id string, clusterName *string) (*User, error)
 	DeleteUser(ctx context.Context, id string, clusterName *string) error
 	FindUserByName(ctx context.Context, name string, clusterName *string) (*User, error)
+	UpdateUser(ctx context.Context, user User, clusterName *string) (*User, error)
 
 	GrantRole(ctx context.Context, grantRole GrantRole, clusterName *string) (*GrantRole, error)
 	GetGrantRole(ctx context.Context, grantedRoleName string, granteeUserName *string, granteeRoleName *string, clusterName *string) (*GrantRole, error)

--- a/internal/dbops/user.go
+++ b/internal/dbops/user.go
@@ -157,8 +157,8 @@ func (i *impl) UpdateUser(ctx context.Context, user User, clusterName *string) (
 		NewAlterUser(existing.Name).
 		WithCluster(clusterName).
 		RenameTo(&user.Name).
-		DropSettingsProfileProfile(existing.SettingsProfile).
-		AddSettingsSettingProfile(user.SettingsProfile).
+		DropSettingsProfile(existing.SettingsProfile).
+		AddSettingsProfile(user.SettingsProfile).
 		Build()
 	if err != nil {
 		return nil, errors.WithMessage(err, "error building query")

--- a/internal/dbops/user.go
+++ b/internal/dbops/user.go
@@ -145,3 +145,28 @@ func (i *impl) FindUserByName(ctx context.Context, name string, clusterName *str
 
 	return i.GetUser(ctx, uuid, clusterName)
 }
+
+func (i *impl) UpdateUser(ctx context.Context, user User, clusterName *string) (*User, error) {
+	// Retrieve current user
+	existing, err := i.GetUser(ctx, user.ID, clusterName)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Unable to get existing user")
+	}
+
+	sql, err := querybuilder.
+		NewAlterUser(existing.Name).
+		WithCluster(clusterName).
+		WithOldSettingProfile(existing.SettingsProfile).
+		WithNewSettingProfile(user.SettingsProfile).
+		Build()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error building query")
+	}
+
+	err = i.clickhouseClient.Exec(ctx, sql)
+	if err != nil {
+		return nil, errors.WithMessage(err, "error running query")
+	}
+
+	return i.GetUser(ctx, user.ID, clusterName)
+}

--- a/internal/dbops/user.go
+++ b/internal/dbops/user.go
@@ -156,8 +156,9 @@ func (i *impl) UpdateUser(ctx context.Context, user User, clusterName *string) (
 	sql, err := querybuilder.
 		NewAlterUser(existing.Name).
 		WithCluster(clusterName).
-		WithOldSettingProfile(existing.SettingsProfile).
-		WithNewSettingProfile(user.SettingsProfile).
+		RenameTo(&user.Name).
+		DropSettingsProfileProfile(existing.SettingsProfile).
+		AddSettingsSettingProfile(user.SettingsProfile).
 		Build()
 	if err != nil {
 		return nil, errors.WithMessage(err, "error building query")

--- a/internal/querybuilder/alteruser.go
+++ b/internal/querybuilder/alteruser.go
@@ -10,8 +10,8 @@ import (
 type AlterUserQueryBuilder interface {
 	QueryBuilder
 	RenameTo(newName *string) AlterUserQueryBuilder
-	DropSettingsProfileProfile(profileName *string) AlterUserQueryBuilder
-	AddSettingsSettingProfile(profileName *string) AlterUserQueryBuilder
+	DropSettingsProfile(profileName *string) AlterUserQueryBuilder
+	AddSettingsProfile(profileName *string) AlterUserQueryBuilder
 	WithCluster(clusterName *string) AlterUserQueryBuilder
 }
 
@@ -35,12 +35,12 @@ func (q *alterUserQueryBuilder) RenameTo(newName *string) AlterUserQueryBuilder 
 	return q
 }
 
-func (q *alterUserQueryBuilder) DropSettingsProfileProfile(profileName *string) AlterUserQueryBuilder {
+func (q *alterUserQueryBuilder) DropSettingsProfile(profileName *string) AlterUserQueryBuilder {
 	q.oldSettingsProfile = profileName
 	return q
 }
 
-func (q *alterUserQueryBuilder) AddSettingsSettingProfile(profileName *string) AlterUserQueryBuilder {
+func (q *alterUserQueryBuilder) AddSettingsProfile(profileName *string) AlterUserQueryBuilder {
 	q.newSettingsProfile = profileName
 	return q
 }

--- a/internal/querybuilder/alteruser.go
+++ b/internal/querybuilder/alteruser.go
@@ -1,0 +1,71 @@
+package querybuilder
+
+import (
+	"strings"
+
+	"github.com/pingcap/errors"
+)
+
+// AlterUserQueryBuilder is an interface to build ALTER USER SQL queries (already interpolated).
+type AlterUserQueryBuilder interface {
+	QueryBuilder
+	WithOldSettingProfile(profileName *string) AlterUserQueryBuilder
+	WithNewSettingProfile(profileName *string) AlterUserQueryBuilder
+	WithCluster(clusterName *string) AlterUserQueryBuilder
+}
+
+type alterUserQueryBuilder struct {
+	resourceName       string
+	oldSettingsProfile *string
+	newSettingsProfile *string
+	clusterName        *string
+}
+
+func NewAlterUser(resourceName string) AlterUserQueryBuilder {
+	return &alterUserQueryBuilder{
+		resourceName: resourceName,
+	}
+}
+
+func (q *alterUserQueryBuilder) WithOldSettingProfile(profileName *string) AlterUserQueryBuilder {
+	q.oldSettingsProfile = profileName
+	return q
+}
+
+func (q *alterUserQueryBuilder) WithNewSettingProfile(profileName *string) AlterUserQueryBuilder {
+	q.newSettingsProfile = profileName
+	return q
+}
+
+func (q *alterUserQueryBuilder) WithCluster(clusterName *string) AlterUserQueryBuilder {
+	q.clusterName = clusterName
+	return q
+}
+
+func (q *alterUserQueryBuilder) Build() (string, error) {
+	if q.resourceName == "" {
+		return "", errors.New("resourceName cannot be empty for ALTER ROLE queries")
+	}
+
+	if (q.oldSettingsProfile == nil && q.newSettingsProfile == nil) ||
+		(q.oldSettingsProfile != nil && q.newSettingsProfile != nil && *q.oldSettingsProfile == *q.newSettingsProfile) {
+		return "", errors.New("no change to be made")
+	}
+
+	tokens := []string{
+		"ALTER",
+		"USER",
+		backtick(q.resourceName),
+	}
+	if q.clusterName != nil {
+		tokens = append(tokens, "ON", "CLUSTER", quote(*q.clusterName))
+	}
+	if q.oldSettingsProfile != nil {
+		tokens = append(tokens, "DROP", "PROFILES", quote(*q.oldSettingsProfile))
+	}
+	if q.newSettingsProfile != nil {
+		tokens = append(tokens, "ADD", "PROFILES", quote(*q.newSettingsProfile))
+	}
+
+	return strings.Join(tokens, " ") + ";", nil
+}

--- a/internal/querybuilder/alteruser_test.go
+++ b/internal/querybuilder/alteruser_test.go
@@ -9,10 +9,24 @@ func Test_alterUserQueryBuilder_Build(t *testing.T) {
 		name               string
 		oldSettingsProfile *string
 		newSettingsProfile *string
+		newName            *string
 		clusterName        *string
 		want               string
 		wantErr            bool
 	}{
+		{
+			name:    "Change name",
+			newName: strPtr("test"),
+			want:    "ALTER USER `foo` RENAME TO `test`;",
+			wantErr: false,
+		},
+		{
+			name:        "Change name on cluster",
+			newName:     strPtr("test"),
+			clusterName: strPtr("cluster1"),
+			want:        "ALTER USER `foo` RENAME TO `test` ON CLUSTER 'cluster1';",
+			wantErr:     false,
+		},
 		{
 			name:               "Add profile",
 			newSettingsProfile: strPtr("profile1"),
@@ -53,6 +67,12 @@ func Test_alterUserQueryBuilder_Build(t *testing.T) {
 			want:               "",
 			wantErr:            true,
 		},
+		{
+			name:    "Same username set",
+			newName: strPtr("foo"),
+			want:    "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +80,7 @@ func Test_alterUserQueryBuilder_Build(t *testing.T) {
 				resourceName:       "foo",
 				oldSettingsProfile: tt.oldSettingsProfile,
 				newSettingsProfile: tt.newSettingsProfile,
+				newName:            tt.newName,
 				clusterName:        tt.clusterName,
 			}
 			got, err := q.Build()

--- a/internal/querybuilder/alteruser_test.go
+++ b/internal/querybuilder/alteruser_test.go
@@ -1,0 +1,75 @@
+package querybuilder
+
+import (
+	"testing"
+)
+
+func Test_alterUserQueryBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldSettingsProfile *string
+		newSettingsProfile *string
+		clusterName        *string
+		want               string
+		wantErr            bool
+	}{
+		{
+			name:               "Add profile",
+			newSettingsProfile: strPtr("profile1"),
+			want:               "ALTER USER `foo` ADD PROFILES 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:               "Replace profile",
+			newSettingsProfile: strPtr("profile1"),
+			oldSettingsProfile: strPtr("old"),
+			want:               "ALTER USER `foo` DROP PROFILES 'old' ADD PROFILES 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:               "Add profile on cluster",
+			newSettingsProfile: strPtr("profile1"),
+			clusterName:        strPtr("cluster1"),
+			want:               "ALTER USER `foo` ON CLUSTER 'cluster1' ADD PROFILES 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:               "Replace profile on cluster",
+			newSettingsProfile: strPtr("profile1"),
+			oldSettingsProfile: strPtr("old"),
+			clusterName:        strPtr("cluster1"),
+			want:               "ALTER USER `foo` ON CLUSTER 'cluster1' DROP PROFILES 'old' ADD PROFILES 'profile1';",
+			wantErr:            false,
+		},
+		{
+			name:    "No profile set",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:               "Same profile set",
+			newSettingsProfile: strPtr("profile1"),
+			oldSettingsProfile: strPtr("profile1"),
+			want:               "",
+			wantErr:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &alterUserQueryBuilder{
+				resourceName:       "foo",
+				oldSettingsProfile: tt.oldSettingsProfile,
+				newSettingsProfile: tt.newSettingsProfile,
+				clusterName:        tt.clusterName,
+			}
+			got, err := q.Build()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Build() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resource/user/user.go
+++ b/pkg/resource/user/user.go
@@ -84,9 +84,6 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"settings_profile": schema.StringAttribute{
 				Optional:    true,
 				Description: "Name of the settings profile to assign to the user",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 		},
 		MarkdownDescription: userResourceDescription,
@@ -211,7 +208,45 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 }
 
 func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	panic("Update of user resource is not supported")
+	var plan, state User
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only field we allow to change is the settings profile.
+	{
+		planValue := plan.SettingsProfile.ValueStringPointer()
+		stateValue := state.SettingsProfile.ValueStringPointer()
+
+		if planValue == nil && stateValue != nil ||
+			planValue != nil && stateValue == nil ||
+			(planValue != nil && stateValue != nil && *planValue != *stateValue) {
+			// Settings profile is changed.
+			user, err := r.client.UpdateUser(ctx, dbops.User{
+				ID:              state.ID.ValueString(),
+				SettingsProfile: plan.SettingsProfile.ValueStringPointer(),
+			}, plan.ClusterName.ValueStringPointer())
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Updating ClickHouse User",
+					fmt.Sprintf("%+v\n", err),
+				)
+				return
+			}
+
+			state.SettingsProfile = types.StringPointerValue(user.SettingsProfile)
+			diags = resp.State.Set(ctx, &state)
+			resp.Diagnostics.Append(diags...)
+		}
+	}
 }
 
 func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/pkg/resource/user/user.go
+++ b/pkg/resource/user/user.go
@@ -218,27 +218,23 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	// Only field we allow to change is the settings profile.
-	{
-		// Settings profile is changed.
-		user, err := r.client.UpdateUser(ctx, dbops.User{
-			ID:              state.ID.ValueString(),
-			Name:            plan.Name.ValueString(),
-			SettingsProfile: plan.SettingsProfile.ValueStringPointer(),
-		}, plan.ClusterName.ValueStringPointer())
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error Updating ClickHouse User",
-				fmt.Sprintf("%+v\n", err),
-			)
-			return
-		}
-
-		state.Name = types.StringValue(user.Name)
-		state.SettingsProfile = types.StringPointerValue(user.SettingsProfile)
-		diags = resp.State.Set(ctx, &state)
-		resp.Diagnostics.Append(diags...)
+	user, err := r.client.UpdateUser(ctx, dbops.User{
+		ID:              state.ID.ValueString(),
+		Name:            plan.Name.ValueString(),
+		SettingsProfile: plan.SettingsProfile.ValueStringPointer(),
+	}, plan.ClusterName.ValueStringPointer())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating ClickHouse User",
+			fmt.Sprintf("%+v\n", err),
+		)
+		return
 	}
+
+	state.Name = types.StringValue(user.Name)
+	state.SettingsProfile = types.StringPointerValue(user.SettingsProfile)
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/sre/issues/448

When we change the settings profile of a user, we want to avoid recreating the user as it's too disruptive operation (for example it causes the user's grants to be lost and it might change the password depending how the customer is setting it).

This PR adds support to change settings profile on a role