### PR TITLE
Simplify settings profile resource and remove association part

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -31,7 +31,6 @@ resource "clickhousedbops_role" "writer" {
 - `cluster_name` (String) Name of the cluster to create the resource into. If omitted, resource will be created on the replica hit by the query.
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
-- `settings_profile` (String) Name of the settings profile to assign to the role
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -46,7 +46,6 @@ resource "clickhousedbops_user" "john" {
 - `cluster_name` (String) Name of the cluster to create the resource into. If omitted, resource will be created on the replica hit by the query.
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
-- `settings_profile` (String) Name of the settings profile to assign to the user
 
 ### Read-Only
 

--- a/examples/tests/grantprivilege/main.tf
+++ b/examples/tests/grantprivilege/main.tf
@@ -18,13 +18,6 @@ resource "clickhousedbops_grant_privilege" "grant_show_to_role" {
   grant_option      = false
 }
 
-resource "clickhousedbops_grant_privilege" "grant_global_privilege" {
-  cluster_name = var.cluster_name
-  privilege_name    = "REMOTE"
-  grantee_role_name = clickhousedbops_role.reader.name
-  grant_option      = false
-}
-
 resource "clickhousedbops_grant_privilege" "grant_dictget_to_role" {
   cluster_name = var.cluster_name
   privilege_name    = "dictGet"

--- a/examples/tests/settingsprofile/main.tf
+++ b/examples/tests/settingsprofile/main.tf
@@ -17,19 +17,3 @@ resource "clickhousedbops_settingsprofile" "profile1" {
     },
   ]
 }
-
-resource "clickhousedbops_role" "tester" {
-  cluster_name = var.cluster_name
-  name = "tester"
-  
-  settings_profile = clickhousedbops_settingsprofile.profile1.name
-}
-
-resource "clickhousedbops_user" "john" {
-  cluster_name = var.cluster_name
-  name = "john"
-  password_sha256_hash_wo = sha256("test")
-  password_sha256_hash_wo_version = 1
-
-  settings_profile = clickhousedbops_settingsprofile.profile1.name
-}

--- a/pkg/resource/role/model.go
+++ b/pkg/resource/role/model.go
@@ -5,8 +5,7 @@ import (
 )
 
 type Role struct {
-	ClusterName     types.String `tfsdk:"cluster_name"`
-	ID              types.String `tfsdk:"id"`
-	Name            types.String `tfsdk:"name"`
-	SettingsProfile types.String `tfsdk:"settings_profile"`
+	ClusterName types.String `tfsdk:"cluster_name"`
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
 }

--- a/pkg/resource/role/role.go
+++ b/pkg/resource/role/role.go
@@ -57,10 +57,6 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				Required:    true,
 				Description: "Name of the role",
 			},
-			"settings_profile": schema.StringAttribute{
-				Optional:    true,
-				Description: "Name of the settings profile to assign to the role",
-			},
 		},
 		MarkdownDescription: roleResourceDescription,
 	}
@@ -117,7 +113,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	createdRole, err := r.client.CreateRole(ctx, dbops.Role{Name: plan.Name.ValueString(), SettingsProfile: plan.SettingsProfile.ValueStringPointer()}, plan.ClusterName.ValueStringPointer())
+	createdRole, err := r.client.CreateRole(ctx, dbops.Role{Name: plan.Name.ValueString()}, plan.ClusterName.ValueStringPointer())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating ClickHouse Role",
@@ -127,10 +123,9 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	state := Role{
-		ClusterName:     plan.ClusterName,
-		ID:              types.StringValue(createdRole.ID),
-		Name:            types.StringValue(createdRole.Name),
-		SettingsProfile: types.StringPointerValue(createdRole.SettingsProfile),
+		ClusterName: plan.ClusterName,
+		ID:          types.StringValue(createdRole.ID),
+		Name:        types.StringValue(createdRole.Name),
 	}
 
 	diags = resp.State.Set(ctx, state)
@@ -159,7 +154,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 
 	if role != nil {
 		state.Name = types.StringValue(role.Name)
-		state.SettingsProfile = types.StringPointerValue(role.SettingsProfile)
 
 		diags = resp.State.Set(ctx, &state)
 		resp.Diagnostics.Append(diags...)
@@ -184,9 +178,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	// Settings profile is changed.
 	role, err := r.client.UpdateRole(ctx, dbops.Role{
-		ID:              state.ID.ValueString(),
-		Name:            plan.Name.ValueString(),
-		SettingsProfile: plan.SettingsProfile.ValueStringPointer(),
+		ID:   state.ID.ValueString(),
+		Name: plan.Name.ValueString(),
 	}, plan.ClusterName.ValueStringPointer())
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -197,7 +190,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	state.Name = types.StringValue(role.Name)
-	state.SettingsProfile = types.StringPointerValue(role.SettingsProfile)
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/pkg/resource/user/model.go
+++ b/pkg/resource/user/model.go
@@ -10,5 +10,4 @@ type User struct {
 	Name                      types.String `tfsdk:"name"`
 	PasswordSha256Hash        types.String `tfsdk:"password_sha256_hash_wo"`
 	PasswordSha256HashVersion types.Int32  `tfsdk:"password_sha256_hash_wo_version"`
-	SettingsProfile           types.String `tfsdk:"settings_profile"`
 }

--- a/pkg/resource/user/user.go
+++ b/pkg/resource/user/user.go
@@ -78,10 +78,6 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 					int32planmodifier.RequiresReplace(),
 				},
 			},
-			"settings_profile": schema.StringAttribute{
-				Optional:    true,
-				Description: "Name of the settings profile to assign to the user",
-			},
 		},
 		MarkdownDescription: userResourceDescription,
 	}
@@ -149,7 +145,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	user := dbops.User{
 		Name:               plan.Name.ValueString(),
 		PasswordSha256Hash: config.PasswordSha256Hash.ValueString(),
-		SettingsProfile:    config.SettingsProfile.ValueStringPointer(),
 	}
 
 	createdUser, err := r.client.CreateUser(ctx, user, plan.ClusterName.ValueStringPointer())
@@ -166,7 +161,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		ID:                        types.StringValue(createdUser.ID),
 		Name:                      types.StringValue(createdUser.Name),
 		PasswordSha256HashVersion: plan.PasswordSha256HashVersion,
-		SettingsProfile:           types.StringPointerValue(createdUser.SettingsProfile),
 	}
 
 	diags = resp.State.Set(ctx, state)
@@ -195,7 +189,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 
 	if user != nil {
 		state.Name = types.StringValue(user.Name)
-		state.SettingsProfile = types.StringPointerValue(user.SettingsProfile)
 
 		diags = resp.State.Set(ctx, &state)
 		resp.Diagnostics.Append(diags...)
@@ -219,9 +212,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	user, err := r.client.UpdateUser(ctx, dbops.User{
-		ID:              state.ID.ValueString(),
-		Name:            plan.Name.ValueString(),
-		SettingsProfile: plan.SettingsProfile.ValueStringPointer(),
+		ID:   state.ID.ValueString(),
+		Name: plan.Name.ValueString(),
 	}, plan.ClusterName.ValueStringPointer())
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -232,7 +224,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	state.Name = types.StringValue(user.Name)
-	state.SettingsProfile = types.StringPointerValue(user.SettingsProfile)
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }


### PR DESCRIPTION
towards: https://github.com/ClickHouse/sre/issues/448

in order to improve UX for people interacting with settings profiles, a major overhaul is needed.
The `settings_profile` field will be removed from the `user` and `role` resources and replaced by a dedicated resource `settingsprofileassociation`.
The `settingsprofile` resource will be much simplified and complemented by another resource:

- settingsprofilesetting: to set settings to a profile

this PR is the first step towards this goal, it removes `settings_profile` attribute from the `user` and `role` resources.