### PR TITLE
Remove "settings" and "inherit_profile" from settingsprofile

### DIFF
--- a/docs/resources/settingsprofile.md
+++ b/docs/resources/settingsprofile.md
@@ -16,24 +16,6 @@ You can use the `clickhousedbops_settingsprofile` resource to create a `Setting 
 resource "clickhousedbops_settingsprofile" "profile1" {
   cluster_name = "cluster"
   name = "profile1"
-  inherit_profile = "default"
-
-  settings = [
-    {
-      name = "max_memory_usage"
-      value = "1000"
-      min = "100"
-      max = "2000"
-      writability = "CHANGEABLE_IN_READONLY"
-    },
-    {
-      name = "max_threads"
-      value = "1000"
-      min = "100"
-      max = "2000"
-      writability = "CONST"
-    },
-  ]
 }
 ```
 
@@ -43,38 +25,32 @@ resource "clickhousedbops_settingsprofile" "profile1" {
 ### Required
 
 - `name` (String) Name of the settings profile
-- `settings` (Attributes List) List of settings to apply to the settings profile. (see [below for nested schema](#nestedatt--settings))
 
 ### Optional
 
 - `cluster_name` (String) Name of the cluster to create the resource into. If omitted, resource will be created on the replica hit by the query.
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
-- `inherit_profile` (String) Name of the profile to inherit from
 
-<a id="nestedatt--settings"></a>
-### Nested Schema for `settings`
+### Read-Only
 
-Required:
-
-- `name` (String) Name of the setting
-
-Optional:
-
-- `max` (String) Max Value for the setting
-- `min` (String) Min Value for the setting
-- `value` (String) Value for the setting
-- `writability` (String) Writability attribute for the setting
+- `id` (String) ID of the settings profile
 
 ## Import
 
 Import is supported using the following syntax:
 
 ```shell
-# Settings profiles can be imported by specifying the name.
+# Settings profiles can be imported by specifying the UUID.
+# Find the ID of the settings profile by checking system.settings_profiles table.
+terraform import clickhousedbops_settingsprofile.example xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# It's also possible to import settings profiles by name:
+
 terraform import clickhousedbops_settingsprofile.example name
 
 # IMPORTANT: if you have a multi node cluster, you need to specify the cluster name!
 
+terraform import clickhousedbops_settingsprofile.example cluster:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 terraform import clickhousedbops_settingsprofile.example cluster:name
 ```

--- a/examples/resources/clickhousedbops_settingsprofile/import.sh
+++ b/examples/resources/clickhousedbops_settingsprofile/import.sh
@@ -1,6 +1,12 @@
-# Settings profiles can be imported by specifying the name.
+# Settings profiles can be imported by specifying the UUID.
+# Find the ID of the settings profile by checking system.settings_profiles table.
+terraform import clickhousedbops_settingsprofile.example xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# It's also possible to import settings profiles by name:
+
 terraform import clickhousedbops_settingsprofile.example name
 
 # IMPORTANT: if you have a multi node cluster, you need to specify the cluster name!
 
+terraform import clickhousedbops_settingsprofile.example cluster:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 terraform import clickhousedbops_settingsprofile.example cluster:name

--- a/examples/resources/clickhousedbops_settingsprofile/resource.tf
+++ b/examples/resources/clickhousedbops_settingsprofile/resource.tf
@@ -1,22 +1,4 @@
 resource "clickhousedbops_settingsprofile" "profile1" {
   cluster_name = "cluster"
   name = "profile1"
-  inherit_profile = "default"
-
-  settings = [
-    {
-      name = "max_memory_usage"
-      value = "1000"
-      min = "100"
-      max = "2000"
-      writability = "CHANGEABLE_IN_READONLY"
-    },
-    {
-      name = "max_threads"
-      value = "1000"
-      min = "100"
-      max = "2000"
-      writability = "CONST"
-    },
-  ]
 }

--- a/examples/tests/settingsprofile/main.tf
+++ b/examples/tests/settingsprofile/main.tf
@@ -1,19 +1,4 @@
 resource "clickhousedbops_settingsprofile" "profile1" {
   cluster_name = var.cluster_name
   name = "profile1"
-  inherit_profile = "default"
-
-  settings = [
-    {
-      name = "max_memory_usage"
-      value = "1000"
-      min = "100"
-      max = "2000"
-      writability = "CHANGEABLE_IN_READONLY"
-    },
-    {
-      name = "network_compression_method"
-      value = "LZ4"
-    },
-  ]
 }

--- a/internal/dbops/interface.go
+++ b/internal/dbops/interface.go
@@ -32,8 +32,10 @@ type Client interface {
 	GetAllGrantsForGrantee(ctx context.Context, granteeUsername *string, granteeRoleName *string, clusterName *string) ([]GrantPrivilege, error)
 
 	CreateSettingsProfile(ctx context.Context, profile SettingsProfile, clusterName *string) (*SettingsProfile, error)
-	GetSettingsProfile(ctx context.Context, name string, clusterName *string) (*SettingsProfile, error)
-	DeleteSettingsProfile(ctx context.Context, name string, clusterName *string) error
+	GetSettingsProfile(ctx context.Context, id string, clusterName *string) (*SettingsProfile, error)
+	DeleteSettingsProfile(ctx context.Context, id string, clusterName *string) error
+	UpdateSettingsProfile(ctx context.Context, settingsProfile SettingsProfile, clusterName *string) (*SettingsProfile, error)
+	FindSettingsProfileByName(ctx context.Context, name string, clusterName *string) (*SettingsProfile, error)
 
 	IsReplicatedStorage(ctx context.Context) (bool, error)
 }

--- a/internal/dbops/settingsprofile.go
+++ b/internal/dbops/settingsprofile.go
@@ -2,6 +2,7 @@ package dbops
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pingcap/errors"
 
@@ -18,23 +19,15 @@ type Setting struct {
 }
 
 type SettingsProfile struct {
+	ID   string `json:"id"`
 	Name string `json:"name"`
-
-	InheritProfile *string
-	Settings       []Setting
 }
 
 func (i *impl) CreateSettingsProfile(ctx context.Context, profile SettingsProfile, clusterName *string) (*SettingsProfile, error) {
-	builder := querybuilder.
+	sql, err := querybuilder.
 		NewCreateSettingsProfile(profile.Name).
 		WithCluster(clusterName).
-		WithInheritProfile(profile.InheritProfile)
-
-	for _, setting := range profile.Settings {
-		builder.AddSetting(setting.Name, setting.Value, setting.Min, setting.Max, setting.Writability)
-	}
-
-	sql, err := builder.Build()
+		Build()
 	if err != nil {
 		return nil, errors.WithMessage(err, "error building query")
 	}
@@ -44,88 +37,37 @@ func (i *impl) CreateSettingsProfile(ctx context.Context, profile SettingsProfil
 		return nil, errors.WithMessage(err, "error running query")
 	}
 
-	return i.GetSettingsProfile(ctx, profile.Name, clusterName)
+	return i.FindSettingsProfileByName(ctx, profile.Name, clusterName)
 }
 
-func (i *impl) GetSettingsProfile(ctx context.Context, name string, clusterName *string) (*SettingsProfile, error) {
+func (i *impl) GetSettingsProfile(ctx context.Context, id string, clusterName *string) (*SettingsProfile, error) {
+	var profile *SettingsProfile
+
 	sql, err := querybuilder.
 		NewSelect(
 			[]querybuilder.Field{
-				querybuilder.NewField("profile_name"),
-				querybuilder.NewField("setting_name"),
-				querybuilder.NewField("value"),
-				querybuilder.NewField("min"),
-				querybuilder.NewField("max"),
-				querybuilder.NewField("writability").ToString(),
-				querybuilder.NewField("inherit_profile"),
+				querybuilder.NewField("name"),
 			},
-			"system.settings_profile_elements",
+			"system.settings_profiles",
 		).
 		WithCluster(clusterName).
-		Where(querybuilder.WhereEquals("profile_name", name)).
-		OrderBy(querybuilder.NewField("index"), querybuilder.ASC).
+		Where(querybuilder.WhereEquals("id", id)).
 		Build()
 	if err != nil {
 		return nil, errors.WithMessage(err, "error building query")
 	}
 
-	var profile *SettingsProfile
-
 	err = i.clickhouseClient.Select(ctx, sql, func(data clickhouseclient.Row) error {
-		n, err := data.GetNullableString("profile_name")
+		name, err := data.GetString("name")
 		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'profile_name' field")
-		}
-
-		settingName, err := data.GetNullableString("setting_name")
-		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'setting_name' field")
-		}
-
-		value, err := data.GetNullableString("value")
-		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'value' field")
-		}
-
-		minVal, err := data.GetNullableString("min")
-		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'min' field")
-		}
-
-		maxVal, err := data.GetNullableString("max")
-		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'max' field")
-		}
-
-		writability, err := data.GetNullableString("writability")
-		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'writability' field")
-		}
-
-		inherit, err := data.GetNullableString("inherit_profile")
-		if err != nil {
-			return errors.WithMessage(err, "error scanning query result, missing 'inherit_profile' field")
+			return errors.WithMessage(err, "error scanning query result, missing 'name' field")
 		}
 
 		if profile == nil {
 			profile = &SettingsProfile{
-				Name:     *n,
-				Settings: make([]Setting, 0),
+				ID:   id,
+				Name: name,
 			}
-		}
-
-		if inherit != nil {
-			profile.InheritProfile = inherit
-		}
-
-		if settingName != nil {
-			profile.Settings = append(profile.Settings, Setting{
-				Name:        *settingName,
-				Value:       value,
-				Min:         minVal,
-				Max:         maxVal,
-				Writability: writability,
-			})
 		}
 
 		return nil
@@ -142,14 +84,14 @@ func (i *impl) GetSettingsProfile(ctx context.Context, name string, clusterName 
 	return profile, nil
 }
 
-func (i *impl) DeleteSettingsProfile(ctx context.Context, name string, clusterName *string) error {
-	profile, err := i.GetSettingsProfile(ctx, name, clusterName)
+func (i *impl) DeleteSettingsProfile(ctx context.Context, id string, clusterName *string) error {
+	profile, err := i.GetSettingsProfile(ctx, id, clusterName)
 	if err != nil {
-		return errors.WithMessage(err, "error getting database name")
+		return errors.WithMessage(err, "error looking up settings profile name")
 	}
 
 	if profile == nil {
-		// This is desired state.
+		// Desired status
 		return nil
 	}
 
@@ -164,4 +106,199 @@ func (i *impl) DeleteSettingsProfile(ctx context.Context, name string, clusterNa
 	}
 
 	return nil
+}
+
+func (i *impl) UpdateSettingsProfile(ctx context.Context, settingsProfile SettingsProfile, clusterName *string) (*SettingsProfile, error) {
+	// Retrieve current setting profile
+	existing, err := i.GetSettingsProfile(ctx, settingsProfile.ID, clusterName)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Unable to get existing settings profile")
+	}
+
+	if existing == nil {
+		return nil, nil
+	}
+
+	sql, err := querybuilder.
+		NewAlterSettingsProfile(existing.Name).
+		WithCluster(clusterName).
+		RenameTo(&settingsProfile.Name).
+		Build()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error building query")
+	}
+
+	err = i.clickhouseClient.Exec(ctx, sql)
+	if err != nil {
+		return nil, errors.WithMessage(err, "error running query")
+	}
+
+	return i.GetSettingsProfile(ctx, settingsProfile.ID, clusterName)
+}
+
+func (i *impl) AssociateSettingsProfile(ctx context.Context, id string, roleId *string, userId *string, clusterName *string) error {
+	profile, err := i.GetSettingsProfile(ctx, id, clusterName)
+	if err != nil {
+		return errors.WithMessage(err, "error looking up settings profile name")
+	}
+
+	if profile == nil {
+		return errors.New("No Settings Profile with such ID found")
+	}
+
+	if roleId != nil {
+		role, err := i.GetRole(ctx, *roleId, clusterName)
+		if err != nil {
+			return errors.WithMessage(err, "Cannot find role")
+		}
+
+		if role == nil {
+			return errors.New("role not found")
+		}
+		sql, err := querybuilder.
+			NewAlterRole(role.Name).
+			WithCluster(clusterName).
+			AddSettingsProfile(&profile.Name).
+			Build()
+		if err != nil {
+			return errors.WithMessage(err, "Error building query")
+		}
+
+		err = i.clickhouseClient.Exec(ctx, sql)
+		if err != nil {
+			return errors.WithMessage(err, "error running query")
+		}
+
+		return nil
+	} else if userId != nil {
+		user, err := i.GetUser(ctx, *userId, clusterName)
+		if err != nil {
+			return errors.WithMessage(err, "Cannot find user")
+		}
+
+		if user == nil {
+			return errors.New("user not found")
+		}
+
+		sql, err := querybuilder.
+			NewAlterUser(user.Name).
+			WithCluster(clusterName).
+			AddSettingsProfile(&profile.Name).
+			Build()
+		if err != nil {
+			return errors.WithMessage(err, "Error building query")
+		}
+
+		err = i.clickhouseClient.Exec(ctx, sql)
+		if err != nil {
+			return errors.WithMessage(err, "error running query")
+		}
+
+		return nil
+	}
+
+	return errors.New("Neither roleId nor userId were specified")
+}
+
+func (i *impl) DisassociateSettingsProfile(ctx context.Context, id string, roleId *string, userId *string, clusterName *string) error {
+	profile, err := i.GetSettingsProfile(ctx, id, clusterName)
+	if err != nil {
+		return errors.WithMessage(err, "error looking up settings profile name")
+	}
+
+	if profile == nil {
+		return errors.New("No Settings Profile with such ID found")
+	}
+
+	if roleId != nil {
+		role, err := i.GetRole(ctx, *roleId, clusterName)
+		if err != nil {
+			return errors.WithMessage(err, "Cannot find role")
+		}
+
+		if role == nil {
+			return errors.New("role not found")
+		}
+
+		sql, err := querybuilder.
+			NewAlterRole(role.Name).
+			WithCluster(clusterName).
+			DropSettingsProfile(&profile.Name).
+			Build()
+		if err != nil {
+			return errors.WithMessage(err, "Error building query")
+		}
+
+		err = i.clickhouseClient.Exec(ctx, sql)
+		if err != nil {
+			return errors.WithMessage(err, "error running query")
+		}
+
+		return nil
+	} else if userId != nil {
+		user, err := i.GetUser(ctx, *userId, clusterName)
+		if err != nil {
+			return errors.WithMessage(err, "Cannot find user")
+		}
+
+		if user == nil {
+			return errors.New("user not found")
+		}
+
+		sql, err := querybuilder.
+			NewAlterUser(user.Name).
+			WithCluster(clusterName).
+			DropSettingsProfile(&profile.Name).
+			Build()
+		if err != nil {
+			return errors.WithMessage(err, "Error building query")
+		}
+
+		err = i.clickhouseClient.Exec(ctx, sql)
+		if err != nil {
+			return errors.WithMessage(err, "error running query")
+		}
+
+		return nil
+	}
+
+	return errors.New("Neither roleId nor userId were specified")
+}
+
+func (i *impl) FindSettingsProfileByName(ctx context.Context, name string, clusterName *string) (*SettingsProfile, error) {
+	sql, err := querybuilder.
+		NewSelect(
+			[]querybuilder.Field{
+				querybuilder.NewField("id").ToString(),
+			},
+			"system.settings_profiles",
+		).
+		WithCluster(clusterName).
+		Where(querybuilder.WhereEquals("name", name)).
+		Build()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error building query")
+	}
+
+	var settingsProfileID string
+
+	err = i.clickhouseClient.Select(ctx, sql, func(data clickhouseclient.Row) error {
+		id, err := data.GetString("id")
+		if err != nil {
+			return errors.WithMessage(err, "error scanning query result, missing 'id' field")
+		}
+
+		settingsProfileID = id
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.WithMessage(err, "error running query")
+	}
+
+	if settingsProfileID == "" {
+		return nil, errors.New(fmt.Sprintf("settings profile with name %s not found", name))
+	}
+
+	return i.GetSettingsProfile(ctx, settingsProfileID, clusterName)
 }

--- a/internal/querybuilder/alterrole.go
+++ b/internal/querybuilder/alterrole.go
@@ -11,7 +11,7 @@ type AlterRoleQueryBuilder interface {
 	QueryBuilder
 	RenameTo(newName *string) AlterRoleQueryBuilder
 	DropSettingsProfile(profileName *string) AlterRoleQueryBuilder
-	AddSettingsSetting(profileName *string) AlterRoleQueryBuilder
+	AddSettingsProfile(profileName *string) AlterRoleQueryBuilder
 	WithCluster(clusterName *string) AlterRoleQueryBuilder
 }
 
@@ -40,7 +40,7 @@ func (q *alterRoleQueryBuilder) DropSettingsProfile(profileName *string) AlterRo
 	return q
 }
 
-func (q *alterRoleQueryBuilder) AddSettingsSetting(profileName *string) AlterRoleQueryBuilder {
+func (q *alterRoleQueryBuilder) AddSettingsProfile(profileName *string) AlterRoleQueryBuilder {
 	q.newSettingsProfile = profileName
 	return q
 }

--- a/internal/querybuilder/createrole.go
+++ b/internal/querybuilder/createrole.go
@@ -9,25 +9,18 @@ import (
 // CreateRoleQueryBuilder is an interface to build CREATE ROLE SQL queries (already interpolated).
 type CreateRoleQueryBuilder interface {
 	QueryBuilder
-	WithSettingsProfile(profileName *string) CreateRoleQueryBuilder
 	WithCluster(clusterName *string) CreateRoleQueryBuilder
 }
 
 type createRoleQueryBuilder struct {
-	resourceName    string
-	settingsProfile *string
-	clusterName     *string
+	resourceName string
+	clusterName  *string
 }
 
 func NewCreateRole(resourceName string) CreateRoleQueryBuilder {
 	return &createRoleQueryBuilder{
 		resourceName: resourceName,
 	}
-}
-
-func (q *createRoleQueryBuilder) WithSettingsProfile(profileName *string) CreateRoleQueryBuilder {
-	q.settingsProfile = profileName
-	return q
 }
 
 func (q *createRoleQueryBuilder) WithCluster(clusterName *string) CreateRoleQueryBuilder {
@@ -47,9 +40,6 @@ func (q *createRoleQueryBuilder) Build() (string, error) {
 	}
 	if q.clusterName != nil {
 		tokens = append(tokens, "ON", "CLUSTER", quote(*q.clusterName))
-	}
-	if q.settingsProfile != nil {
-		tokens = append(tokens, "SETTINGS", "PROFILE", quote(*q.settingsProfile))
 	}
 
 	return strings.Join(tokens, " ") + ";", nil

--- a/internal/querybuilder/createrole_test.go
+++ b/internal/querybuilder/createrole_test.go
@@ -27,13 +27,6 @@ func Test_createrole(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:            "Create role with settings profile",
-			resourceName:    "foo",
-			settingsProfile: "test",
-			want:            "CREATE ROLE `foo` SETTINGS PROFILE 'test';",
-			wantErr:         false,
-		},
-		{
 			name:         "Create role on cluster",
 			resourceName: "foo",
 			clusterName:  "cluster1",
@@ -46,10 +39,6 @@ func Test_createrole(t *testing.T) {
 			var q CreateRoleQueryBuilder
 			q = &createRoleQueryBuilder{
 				resourceName: tt.resourceName,
-			}
-
-			if tt.settingsProfile != "" {
-				q = q.WithSettingsProfile(&tt.settingsProfile)
 			}
 
 			if tt.clusterName != "" {

--- a/internal/querybuilder/createsettingsprofile.go
+++ b/internal/querybuilder/createsettingsprofile.go
@@ -63,22 +63,20 @@ func (q *createSettingsProfileQueryBuilder) Build() (string, error) {
 		tokens = append(tokens, "ON", "CLUSTER", quote(*q.clusterName))
 	}
 
-	if len(q.settings) == 0 {
-		return "", errors.New("cannot create settings profile with no settings")
-	}
+	if len(q.settings) > 0 {
+		tokens = append(tokens, "SETTINGS")
 
-	tokens = append(tokens, "SETTINGS")
-
-	renderedSettings := make([]string, 0)
-	for _, s := range q.settings {
-		def, err := s.SQLDef()
-		if err != nil {
-			return "", errors.WithMessage(err, "Error building query")
+		renderedSettings := make([]string, 0)
+		for _, s := range q.settings {
+			def, err := s.SQLDef()
+			if err != nil {
+				return "", errors.WithMessage(err, "Error building query")
+			}
+			renderedSettings = append(renderedSettings, def)
 		}
-		renderedSettings = append(renderedSettings, def)
-	}
 
-	tokens = append(tokens, strings.Join(renderedSettings, ", "))
+		tokens = append(tokens, strings.Join(renderedSettings, ", "))
+	}
 
 	if q.inheritProfile != nil {
 		tokens = append(tokens, "INHERIT", quote(*q.inheritProfile))

--- a/internal/querybuilder/createsettingsprofile_test.go
+++ b/internal/querybuilder/createsettingsprofile_test.go
@@ -31,14 +31,6 @@ func Test_createSettingsProfileQueryBuilder_Build(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:        "No settings",
-			profileName: "prf1",
-			clusterName: nil,
-			settings:    nil,
-			want:        "",
-			wantErr:     true,
-		},
-		{
 			name:        "on cluster",
 			profileName: "prf1",
 			clusterName: strPtr("cluster1"),

--- a/internal/querybuilder/setting.go
+++ b/internal/querybuilder/setting.go
@@ -39,7 +39,7 @@ func (s *settingData) SQLDef() (string, error) {
 	}
 
 	singleSetting := make([]string, 0)
-	singleSetting = append(singleSetting, s.Name)
+	singleSetting = append(singleSetting, backtick(s.Name))
 	if s.Value != nil {
 		singleSetting = append(singleSetting, "=", quote(*s.Value))
 	}

--- a/internal/querybuilder/setting_test.go
+++ b/internal/querybuilder/setting_test.go
@@ -33,7 +33,7 @@ func Test_setting_SQLDef(t *testing.T) {
 				Name:  "test",
 				Value: strPtr("123"),
 			},
-			want:    "test = '123'",
+			want:    "`test` = '123'",
 			wantErr: false,
 		},
 		{
@@ -42,7 +42,7 @@ func Test_setting_SQLDef(t *testing.T) {
 				Name: "test",
 				Min:  strPtr("456"),
 			},
-			want:    "test MIN '456'",
+			want:    "`test` MIN '456'",
 			wantErr: false,
 		},
 		{
@@ -51,7 +51,7 @@ func Test_setting_SQLDef(t *testing.T) {
 				Name: "test",
 				Max:  strPtr("789"),
 			},
-			want:    "test MAX '789'",
+			want:    "`test` MAX '789'",
 			wantErr: false,
 		},
 		{
@@ -61,7 +61,7 @@ func Test_setting_SQLDef(t *testing.T) {
 				Min:  strPtr("10"),
 				Max:  strPtr("100"),
 			},
-			want:    "test MIN '10' MAX '100'",
+			want:    "`test` MIN '10' MAX '100'",
 			wantErr: false,
 		},
 		{
@@ -72,7 +72,7 @@ func Test_setting_SQLDef(t *testing.T) {
 				Min:   strPtr("10"),
 				Max:   strPtr("100"),
 			},
-			want:    "test = '50' MIN '10' MAX '100'",
+			want:    "`test` = '50' MIN '10' MAX '100'",
 			wantErr: false,
 		},
 	}

--- a/pkg/resource/settingsprofile/model.go
+++ b/pkg/resource/settingsprofile/model.go
@@ -1,44 +1,11 @@
 package settingsprofile
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type SettingsProfile struct {
-	ClusterName    types.String `tfsdk:"cluster_name"`
-	Name           types.String `tfsdk:"name"`
-	Settings       types.List   `tfsdk:"settings"`
-	InheritProfile types.String `tfsdk:"inherit_profile"`
-}
-
-type Setting struct {
+	ClusterName types.String `tfsdk:"cluster_name"`
+	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
-	Value       types.String `tfsdk:"value"`
-	Min         types.String `tfsdk:"min"`
-	Max         types.String `tfsdk:"max"`
-	Writability types.String `tfsdk:"writability"`
-}
-
-func (i Setting) ObjectType() types.ObjectType {
-	return types.ObjectType{
-		AttrTypes: map[string]attr.Type{
-			"name":        types.StringType,
-			"value":       types.StringType,
-			"min":         types.StringType,
-			"max":         types.StringType,
-			"writability": types.StringType,
-		},
-	}
-}
-
-func (i Setting) ObjectValue() basetypes.ObjectValue {
-	return types.ObjectValueMust(i.ObjectType().AttrTypes, map[string]attr.Value{
-		"name":        i.Name,
-		"value":       i.Value,
-		"min":         i.Min,
-		"max":         i.Max,
-		"writability": i.Writability,
-	})
 }

--- a/pkg/resource/settingsprofile/settingsprofile_test.go
+++ b/pkg/resource/settingsprofile/settingsprofile_test.go
@@ -46,50 +46,8 @@ func TestRole_acceptance(t *testing.T) {
 			return fmt.Errorf("settings profile named %q was not found", name)
 		}
 
-		// Check state fields are aligned with the role we retrieved from CH.
-		if !nilcompare.NilCompare(attrs["inherit_profile"], profile.InheritProfile) {
-			return fmt.Errorf("wrong value for inherit_profile attribute")
-		}
-
 		if !nilcompare.NilCompare(clusterName, attrs["cluster_name"]) {
 			return fmt.Errorf("wrong value for cluster_name attribute")
-		}
-
-		if len(profile.Settings) != len(attrs["settings"].([]interface{})) {
-			return fmt.Errorf("invalid number of settings")
-		}
-
-		for _, setting := range profile.Settings {
-			// Look for the same setting in the attributes
-			stateSettings := attrs["settings"].([]interface{})
-			found := false
-
-			for _, stateSetting := range stateSettings {
-				state := stateSetting.(map[string]interface{})
-				if setting.Name == state["name"].(string) {
-					found = true
-					if !nilcompare.NilCompare(setting.Value, state["value"]) {
-						return fmt.Errorf("invalid Value for setting %q", setting.Name)
-					}
-
-					if !nilcompare.NilCompare(setting.Min, state["min"]) {
-						return fmt.Errorf("invalid Min for setting %q", setting.Name)
-					}
-
-					if !nilcompare.NilCompare(setting.Max, state["max"]) {
-						return fmt.Errorf("invalid Max for setting %q", setting.Name)
-					}
-
-					if !nilcompare.NilCompare(setting.Writability, state["writability"]) {
-						return fmt.Errorf("invalid Writability for setting %q", setting.Name)
-					}
-					break
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("setting %q was not found in the state", setting.Name)
-			}
 		}
 
 		return nil


### PR DESCRIPTION
towards: https://github.com/ClickHouse/sre/issues/448

in order to improve UX for people interacting with settings profiles, a major overhaul is needed.

The settingsprofile resource will be much simplified and complemented by another resource:

-  settingsprofilesetting: to set settings to a profile

this PR removes the `settings` and `inherit_profile` fields from `settingsprofile` resource + a couple files I forgot to push in the previous commit