### PR TITLE
fix(clickhousedbops): fix panic - unknown data type "Enum16" on grant permissions via HTTP client

### DIFF
--- a/internal/clickhouseclient/http.go
+++ b/internal/clickhouseclient/http.go
@@ -111,7 +111,7 @@ func (i *httpClient) runQuery(ctx context.Context, qry string) (string, error) {
 
 	req, err := http.NewRequest(http.MethodPost, i.baseUrl.String(), strings.NewReader(qry))
 	if err != nil {
-		return "", errors.WithMessage(err, "error prepary HTTP request")
+		return "", errors.WithMessage(err, "error preparing HTTP request")
 	}
 
 	req.Header.Add("X-ClickHouse-Format", "JSONCompactStrings")

--- a/internal/dbops/grantprivilege.go
+++ b/internal/dbops/grantprivilege.go
@@ -197,7 +197,7 @@ func (i *impl) GetAllGrantsForGrantee(ctx context.Context, granteeUsername *stri
 	}
 
 	sql, err := querybuilder.NewSelect([]querybuilder.Field{
-		querybuilder.NewField("access_type"),
+		querybuilder.NewField("access_type").ToString(),
 		querybuilder.NewField("database"),
 		querybuilder.NewField("table"),
 		querybuilder.NewField("column"),


### PR DESCRIPTION
Fix panic - unknown data type "Enum16" on grant permissions via HTTP client.
`clickhousedbops_grant_privilege` returns panic when granting composite privilege like `ALL`, etc.
```
│ Error: Plugin did not respond
│
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-clickhousedbops plugin:

panic: unknown data type "Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, 'CHECK' = 2, 'SHOW COLUMNS' = 3, 'SHOW DICTIONARIES' = 4, 'SHOW' = 5, 'SHOW FILESYSTEM CACHES' = 6, 'SELECT' = 7, 'INSERT' = 8, 'ALTER UPDATE' = 9, 'ALTER DELETE' = 10, 'ALTER ADD COLUMN' = 11, 'ALTER MODIFY COLUMN' = 12, 'ALTER DROP COLUMN' = 13, 'ALTER COMMENT COLUMN' = 14, 'ALTER CLEAR COLUMN' = 15, 'ALTER RENAME COLUMN' = 16, 'ALTER MATERIALIZE COLUMN' = 17, 'ALTER COLUMN' = 18, 'ALTER MODIFY COMMENT' = 19, 'ALTER MODIFY DATABASE COMMENT' = 20, 'ALTER ORDER BY' = 21, 'ALTER SAMPLE BY' = 22, 'ALTER ADD INDEX' = 23, 'ALTER DROP INDEX' = 24, 'ALTER MATERIALIZE INDEX' = 25, 'ALTER CLEAR INDEX' = 26, 'ALTER INDEX' = 27, 'ALTER ADD STATISTICS' = 28, 'ALTER DROP STATISTICS' = 29, 'ALTER MODIFY STATISTICS' = 30, 'ALTER MATERIALIZE STATISTICS' = 31, 'ALTER STATISTICS' = 32, 'ALTER ADD PROJECTION' = 33, 'ALTER DROP PROJECTION' = 34, 'ALTER MATERIALIZE PROJECTION' = 35, 'ALTER CLEAR PROJECTION' = 36, 'ALTER PROJECTION' = 37, 'ALTER ADD CONSTRAINT' = 38, 'ALTER DROP CONSTRAINT' = 39, 'ALTER CONSTRAINT' = 40, 'ALTER TTL' = 41, 'ALTER MATERIALIZE TTL' = 42, 'ALTER SETTINGS' = 43, 'ALTER MOVE PARTITION' = 44, 'ALTER FETCH PARTITION' = 45, 'ALTER FREEZE PARTITION' = 46, 'ALTER UNLOCK SNAPSHOT' = 47, 'ALTER DATABASE SETTINGS' = 48, 'ALTER NAMED COLLECTION' = 49, 'ALTER TABLE' = 50, 'ALTER DATABASE' = 51, 'ALTER VIEW MODIFY QUERY' = 52, 'ALTER VIEW MODIFY REFRESH' = 53, 'ALTER VIEW MODIFY SQL SECURITY' = 54, 'ALTER VIEW' = 55, 'ALTER' = 56, 'CREATE DATABASE' = 57, 'CREATE TABLE' = 58, 'CREATE VIEW' = 59, 'CREATE DICTIONARY' = 60, 'CREATE TEMPORARY TABLE' = 61, 'CREATE ARBITRARY TEMPORARY TABLE' = 62, 'CREATE FUNCTION' = 63, 'CREATE WORKLOAD' = 64, 'CREATE RESOURCE' = 65, 'CREATE NAMED COLLECTION' = 66, 'CREATE' = 67, 'DROP DATABASE' = 68, 'DROP TABLE' = 69, 'DROP VIEW' = 70, 'DROP DICTIONARY' = 71, 'DROP FUNCTION' = 72, 'DROP WORKLOAD' = 73, 'DROP RESOURCE' = 74, 'DROP NAMED COLLECTION' = 75, 'DROP' = 76, 'UNDROP TABLE' = 77, 'TRUNCATE' = 78, 'OPTIMIZE' = 79, 'BACKUP' = 80, 'KILL QUERY' = 81, 'KILL TRANSACTION' = 82, 'MOVE PARTITION BETWEEN SHARDS' = 83, 'CREATE USER' = 84, 'ALTER USER' = 85, 'DROP USER' = 86, 'CREATE ROLE' = 87, 'ALTER ROLE' = 88, 'DROP ROLE' = 89, 'ROLE ADMIN' = 90, 'CREATE ROW POLICY' = 91, 'ALTER ROW POLICY' = 92, 'DROP ROW POLICY' = 93, 'CREATE QUOTA' = 94, 'ALTER QUOTA' = 95, 'DROP QUOTA' = 96, 'CREATE SETTINGS PROFILE' = 97, 'ALTER SETTINGS PROFILE' = 98, 'DROP SETTINGS PROFILE' = 99, 'ALLOW SQL SECURITY NONE' = 100, 'SHOW USERS' = 101, 'SHOW ROLES' = 102, 'SHOW ROW POLICIES' = 103, 'SHOW QUOTAS' = 104, 'SHOW SETTINGS PROFILES' = 105, 'SHOW ACCESS' = 106, 'ACCESS MANAGEMENT' = 107, 'SHOW NAMED COLLECTIONS' = 108, 'SHOW NAMED COLLECTIONS SECRETS' = 109, 'NAMED COLLECTION' = 110, 'NAMED COLLECTION ADMIN' = 111, 'SET DEFINER' = 112, 'TABLE ENGINE' = 113, 'SYSTEM SHUTDOWN' = 114, 'SYSTEM DROP DNS CACHE' = 115, 'SYSTEM DROP CONNECTIONS CACHE' = 116, 'SYSTEM PREWARM MARK CACHE' = 117, 'SYSTEM DROP MARK CACHE' = 118, 'SYSTEM DROP ICEBERG METADATA CACHE' = 119, 'SYSTEM PREWARM PRIMARY INDEX CACHE' = 120, 'SYSTEM DROP PRIMARY INDEX CACHE' = 121, 'SYSTEM DROP UNCOMPRESSED CACHE' = 122, 'SYSTEM DROP VECTOR SIMILARITY INDEX CACHE' = 123, 'SYSTEM DROP MMAP CACHE' = 124, 'SYSTEM DROP QUERY CONDITION CACHE' = 125, 'SYSTEM DROP QUERY CACHE' = 126, 'SYSTEM DROP COMPILED EXPRESSION CACHE' = 127, 'SYSTEM DROP FILESYSTEM CACHE' = 128, 'SYSTEM DROP DISTRIBUTED CACHE' = 129, 'SYSTEM SYNC FILESYSTEM CACHE' = 130, 'SYSTEM DROP PAGE CACHE' = 131, 'SYSTEM DROP SCHEMA CACHE' = 132, 'SYSTEM DROP FORMAT SCHEMA CACHE' = 133, 'SYSTEM DROP S3 CLIENT CACHE' = 134, 'SYSTEM DROP CACHE' = 135, 'SYSTEM RELOAD CONFIG' = 136, 'SYSTEM RELOAD USERS' = 137, 'SYSTEM RELOAD DICTIONARY' = 138, 'SYSTEM RELOAD MODEL' = 139, 'SYSTEM RELOAD FUNCTION' = 140, 'SYSTEM RELOAD EMBEDDED DICTIONARIES' = 141, 'SYSTEM RELOAD ASYNCHRONOUS METRICS' = 142, 'SYSTEM RELOAD' = 143, 'SYSTEM RESTART DISK' = 144, 'SYSTEM MERGES' = 145, 'SYSTEM TTL MERGES' = 146, 'SYSTEM FETCHES' = 147, 'SYSTEM MOVES' = 148, 'SYSTEM PULLING REPLICATION LOG' = 149, 'SYSTEM CLEANUP' = 150, 'SYSTEM VIEWS' = 151, 'SYSTEM DISTRIBUTED SENDS' = 152, 'SYSTEM REPLICATED SENDS' = 153, 'SYSTEM SENDS' = 154, 'SYSTEM REPLICATION QUEUES' = 155, 'SYSTEM VIRTUAL PARTS UPDATE' = 156, 'SYSTEM REDUCE BLOCKING PARTS' = 157, 'SYSTEM DROP REPLICA' = 158, 'SYSTEM SYNC REPLICA' = 159, 'SYSTEM REPLICA READINESS' = 160, 'SYSTEM RESTART REPLICA' = 161, 'SYSTEM RESTORE REPLICA' = 162, 'SYSTEM WAIT LOADING PARTS' = 163, 'SYSTEM SYNC DATABASE REPLICA' = 164, 'SYSTEM SYNC TRANSACTION LOG' = 165, 'SYSTEM SYNC FILE CACHE' = 166, 'SYSTEM FLUSH DISTRIBUTED' = 167, 'SYSTEM FLUSH LOGS' = 168, 'SYSTEM FLUSH ASYNC INSERT QUEUE' = 169, 'SYSTEM FLUSH' = 170, 'SYSTEM THREAD FUZZER' = 171, 'SYSTEM UNFREEZE' = 172, 'SYSTEM UNLOCK SNAPSHOT' = 173, 'SYSTEM FAILPOINT' = 174, 'SYSTEM LISTEN' = 175, 'SYSTEM JEMALLOC' = 176, 'SYSTEM LOAD PRIMARY KEY' = 177, 'SYSTEM UNLOAD PRIMARY KEY' = 178, 'SYSTEM' = 179, 'dictGet' = 180, 'displaySecretsInShowAndSelect' = 181, 'addressToLine' = 182, 'addressToLineWithInlines' = 183, 'addressToSymbol' = 184, 'demangle' = 185, 'INTROSPECTION' = 186, 'FILE' = 187, 'URL' = 188, 'REMOTE' = 189, 'MONGO' = 190, 'REDIS' = 191, 'MYSQL' = 192, 'POSTGRES' = 193, 'SQLITE' = 194, 'ODBC' = 195, 'JDBC' = 196, 'HDFS' = 197, 'S3' = 198, 'HIVE' = 199, 'AZURE' = 200, 'KAFKA' = 201, 'NATS' = 202, 'RABBITMQ' = 203, 'SOURCES' = 204, 'CLUSTER' = 205, 'ALL' = 206, 'NONE' = 207)"
```
