### PR TITLE
fix(grants): support expanded privileges

### DIFF
--- a/internal/dbops/grantprivilege.go
+++ b/internal/dbops/grantprivilege.go
@@ -41,6 +41,11 @@ type GrantPrivilege struct {
 	GranteeUserName *string `json:"user_name"`
 	GranteeRoleName *string `json:"role_name"`
 	GrantOption     bool    `json:"grant_option"`
+	// ExpandedAccessTypes includes AccessType and all its descendants.
+	// ClickHouse may expand a parent privilege (e.g. CREATE, ACCESS MANAGEMENT)
+	// into its children in system.grants instead of storing a single parent row.
+	// Setting this field allows the matcher to find the grant in either case.
+	ExpandedAccessTypes []string `json:"-"`
 }
 
 // Defines the signature for a function that checks if privileges are granted.
@@ -102,8 +107,13 @@ func ClassicGrantMatcher(ctx context.Context, priv *GrantPrivilege, clusterName 
 		tblName = &stripped
 	}
 
+	accessTypes := priv.ExpandedAccessTypes
+	if len(accessTypes) == 0 {
+		accessTypes = []string{priv.AccessType}
+	}
+
 	where := []querybuilder.Where{
-		querybuilder.WhereEquals("access_type", priv.AccessType),
+		querybuilder.WhereIn("access_type", accessTypes),
 		valOrNullWhere("database", dbName),
 		valOrNullWhere("table", tblName),
 		valOrNullWhere("column", priv.ColumnName),

--- a/pkg/resource/grantprivilege/grantprivilege.go
+++ b/pkg/resource/grantprivilege/grantprivilege.go
@@ -48,7 +48,7 @@ func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, res
 func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	validPrivileges := make([]string, 0)
 
-	upstrGrts := parseGrants()
+	upstrGrts := parsedGrants()
 
 	for privilege := range upstrGrts.Scopes {
 		validPrivileges = append(validPrivileges, privilege)
@@ -169,7 +169,7 @@ func (r *Resource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReques
 		return
 	}
 
-	upstrGrts := parseGrants()
+	upstrGrts := parsedGrants()
 
 	var plan, state, config GrantPrivilege
 	diags := req.Plan.Get(ctx, &plan)
@@ -271,14 +271,16 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
+	upstrGrts := parsedGrants()
 	grant := dbops.GrantPrivilege{
-		AccessType:      plan.Privilege.ValueString(),
-		DatabaseName:    plan.Database.ValueStringPointer(),
-		TableName:       plan.Table.ValueStringPointer(),
-		ColumnName:      plan.Column.ValueStringPointer(),
-		GranteeUserName: plan.GranteeUserName.ValueStringPointer(),
-		GranteeRoleName: plan.GranteeRoleName.ValueStringPointer(),
-		GrantOption:     plan.GrantOption.ValueBool(),
+		AccessType:          plan.Privilege.ValueString(),
+		ExpandedAccessTypes: AllDescendants(upstrGrts.Groups, plan.Privilege.ValueString()),
+		DatabaseName:        plan.Database.ValueStringPointer(),
+		TableName:           plan.Table.ValueStringPointer(),
+		ColumnName:          plan.Column.ValueStringPointer(),
+		GranteeUserName:     plan.GranteeUserName.ValueStringPointer(),
+		GranteeRoleName:     plan.GranteeRoleName.ValueStringPointer(),
+		GrantOption:         plan.GrantOption.ValueBool(),
 	}
 
 	createdGrant, err := r.client.GrantPrivilege(ctx, grant, plan.ClusterName.ValueStringPointer())
@@ -354,14 +356,16 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
+	upstrGrts := parsedGrants()
 	grantPrivilege := dbops.GrantPrivilege{
-		AccessType:      state.Privilege.ValueString(),
-		DatabaseName:    state.Database.ValueStringPointer(),
-		TableName:       state.Table.ValueStringPointer(),
-		ColumnName:      state.Column.ValueStringPointer(),
-		GranteeUserName: state.GranteeUserName.ValueStringPointer(),
-		GranteeRoleName: state.GranteeRoleName.ValueStringPointer(),
-		GrantOption:     state.GrantOption.ValueBool(),
+		AccessType:          state.Privilege.ValueString(),
+		ExpandedAccessTypes: AllDescendants(upstrGrts.Groups, state.Privilege.ValueString()),
+		DatabaseName:        state.Database.ValueStringPointer(),
+		TableName:           state.Table.ValueStringPointer(),
+		ColumnName:          state.Column.ValueStringPointer(),
+		GranteeUserName:     state.GranteeUserName.ValueStringPointer(),
+		GranteeRoleName:     state.GranteeRoleName.ValueStringPointer(),
+		GrantOption:         state.GrantOption.ValueBool(),
 	}
 
 	grant, err := r.client.GetGrantPrivilege(ctx, &grantPrivilege, state.ClusterName.ValueStringPointer())

--- a/pkg/resource/grantprivilege/grantprivilege_test.go
+++ b/pkg/resource/grantprivilege/grantprivilege_test.go
@@ -2,6 +2,7 @@ package grantprivilege_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"testing"
 
@@ -9,7 +10,11 @@ import (
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/testutils/nilcompare"
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/testutils/resourcebuilder"
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/testutils/runner"
+	"github.com/ClickHouse/terraform-provider-clickhousedbops/pkg/resource/grantprivilege"
 )
+
+//go:embed grants.tsv
+var testGrantsTSV string
 
 const (
 	resourceType = "clickhousedbops_grant_privilege"
@@ -21,6 +26,8 @@ const (
 
 func TestGrantprivilege_acceptance(t *testing.T) {
 	clusterName := "cluster1"
+
+	grantsGroups := grantprivilege.ParseGrantsTSV(testGrantsTSV).Groups
 
 	granteeRoleResource := resourcebuilder.
 		New("clickhousedbops_role", granteeRoleName).
@@ -71,19 +78,20 @@ func TestGrantprivilege_acceptance(t *testing.T) {
 		}
 
 		grantPrivilege := dbops.GrantPrivilege{
-			AccessType:      accessType,
-			DatabaseName:    database,
-			TableName:       table,
-			ColumnName:      column,
-			GranteeUserName: granteeUserName,
-			GranteeRoleName: granteeRoleName,
+			AccessType:          accessType,
+			ExpandedAccessTypes: grantprivilege.AllDescendants(grantsGroups, accessType),
+			DatabaseName:        database,
+			TableName:           table,
+			ColumnName:          column,
+			GranteeUserName:     granteeUserName,
+			GranteeRoleName:     granteeRoleName,
 		}
 
 		grantprivilege, err := dbopsClient.GetGrantPrivilege(ctx, &grantPrivilege, clusterName)
 		return grantprivilege != nil, err
 	}
 
-	checkAttributesFunc := func(ctx context.Context, dbopsClient dbops.Client, clusterName *string, attrs map[string]interface{}) error {
+	checkAttributesFunc := func(ctx context.Context, dbopsClient dbops.Client, clusterName *string, attrs map[string]any) error {
 		accessType := attrs["privilege_name"].(string)
 		if accessType == "" {
 			return fmt.Errorf("privilege_name attribute was not set")
@@ -129,13 +137,14 @@ func TestGrantprivilege_acceptance(t *testing.T) {
 		}
 
 		grantPrivilege := dbops.GrantPrivilege{
-			AccessType:      accessType,
-			DatabaseName:    database,
-			TableName:       table,
-			ColumnName:      column,
-			GranteeUserName: granteeUserName,
-			GranteeRoleName: granteeRoleName,
-			GrantOption:     grantOption,
+			AccessType:          accessType,
+			ExpandedAccessTypes: grantprivilege.AllDescendants(grantsGroups, accessType),
+			DatabaseName:        database,
+			TableName:           table,
+			ColumnName:          column,
+			GranteeUserName:     granteeUserName,
+			GranteeRoleName:     granteeRoleName,
+			GrantOption:         grantOption,
 		}
 
 		grantprivilege, err := dbopsClient.GetGrantPrivilege(ctx, &grantPrivilege, clusterName)
@@ -224,6 +233,35 @@ func TestGrantprivilege_acceptance(t *testing.T) {
 				WithResourceFieldReference("grantee_user_name", "clickhousedbops_user", granteeUserName, "name").
 				WithBoolAttribute("grant_option", true).
 				AddDependency(granteeUserResource.Build()).
+				Build(),
+			ResourceName:        resourceName,
+			ResourceAddress:     fmt.Sprintf("%s.%s", resourceType, resourceName),
+			CheckNotExistsFunc:  checkNotExistsFunc,
+			CheckAttributesFunc: checkAttributesFunc,
+		},
+		{
+			Name:     "Grant global parent privilege ACCESS MANAGEMENT to role using Native protocol on a single replica",
+			ChEnv:    map[string]string{"CONFIGFILE": "config-single.xml"},
+			Protocol: "native",
+			Resource: resourcebuilder.New(resourceType, resourceName).
+				WithStringAttribute("privilege_name", "ACCESS MANAGEMENT").
+				WithResourceFieldReference("grantee_role_name", "clickhousedbops_role", granteeRoleName, "name").
+				AddDependency(granteeRoleResource.Build()).
+				Build(),
+			ResourceName:        resourceName,
+			ResourceAddress:     fmt.Sprintf("%s.%s", resourceType, resourceName),
+			CheckNotExistsFunc:  checkNotExistsFunc,
+			CheckAttributesFunc: checkAttributesFunc,
+		},
+		{
+			Name:     "Grant parent privilege CREATE on a database to role using Native protocol on a single replica",
+			ChEnv:    map[string]string{"CONFIGFILE": "config-single.xml"},
+			Protocol: "native",
+			Resource: resourcebuilder.New(resourceType, resourceName).
+				WithStringAttribute("privilege_name", "CREATE").
+				WithStringAttribute("database_name", "default").
+				WithResourceFieldReference("grantee_role_name", "clickhousedbops_role", granteeRoleName, "name").
+				AddDependency(granteeRoleResource.Build()).
 				Build(),
 			ResourceName:        resourceName,
 			ResourceAddress:     fmt.Sprintf("%s.%s", resourceType, resourceName),

--- a/pkg/resource/grantprivilege/grants.go
+++ b/pkg/resource/grantprivilege/grants.go
@@ -5,29 +5,39 @@ import (
 	_ "embed"
 	"log"
 	"strings"
+	"sync"
 )
 
 //go:generate curl -so grants.tsv https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/tests/queries/0_stateless/01271_show_privileges.reference
 //go:embed grants.tsv
 var grants string
 
+// parsedGrants caches the result of parsing the embedded grants.tsv exactly once.
+// The TSV is static (embedded at build time), so the result never changes.
+var parsedGrants = sync.OnceValue(parseGrants)
+
 // parseGrants reads the grants.tsv file and turns it into a data structure to get information about all available permissions users can grant.
 // The .tsv file comes from clickhouse core code and should be updated every time there is a change in permissions upstream.
 // information returned by this function is used for validation of user inputs.
 func parseGrants() availableGrants {
+	return ParseGrantsTSV(grants)
+}
+
+// ParseGrantsTSV builds the full privilege hierarchy from TSV data.
+// The TSV format comes from ClickHouse's 01271_show_privileges.reference.
+func ParseGrantsTSV(data string) availableGrants {
 	aliases := make(map[string]string)
 	groups := make(map[string][]string)
 	scopes := make(map[string]string)
 
-	scanner := bufio.NewScanner(strings.NewReader(grants))
+	scanner := bufio.NewScanner(strings.NewReader(data))
 	for scanner.Scan() {
 		line := scanner.Text()
-
 		splitted := strings.Split(line, "\t")
 
 		clean := strings.ReplaceAll(strings.Trim(splitted[1], "[]"), "'", "")
 		if clean != "" {
-			for _, a := range strings.Split(clean, ",") {
+			for a := range strings.SplitSeq(clean, ",") {
 				if a != splitted[0] {
 					aliases[a] = splitted[0]
 				}
@@ -57,4 +67,15 @@ func parseGrants() availableGrants {
 	}
 
 	return ret
+}
+
+// AllDescendants returns the privilege itself plus all its descendants
+// (children, grandchildren, etc.) from the hierarchy.
+// For a leaf privilege with no children it returns a single-element slice.
+func AllDescendants(groups map[string][]string, privilege string) []string {
+	result := []string{privilege}
+	for _, child := range groups[privilege] {
+		result = append(result, AllDescendants(groups, child)...)
+	}
+	return result
 }


### PR DESCRIPTION
Leverage `grants.tsv` to identify expanded access types for validation purposes. 

Fixes:
- https://github.com/ClickHouse/terraform-provider-clickhousedbops/issues/89
- https://github.com/ClickHouse/terraform-provider-clickhousedbops/issues/170