### PR TITLE
feat(provider): add configurable timeout for ClickHouse connections

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ provider "clickhousedbops" {
 
 ### Optional
 
+- `dial_timeout` (Number) Timeout in seconds for establishing connections to ClickHouse. Only applies to the native and nativesecure protocols. Useful when the ClickHouse instance takes time to start up from an idle state.
 - `read_after_write_timeout` (Number) Timeout in seconds for read-after-write verification of created resources. ClickHouse Cloud services with multiple replicas may need higher values due to replication lag. Defaults to 30.
 - `tls_config` (Attributes) TLS configuration options (see [below for nested schema](#nestedatt--tls_config))
 

--- a/internal/clickhouseclient/native.go
+++ b/internal/clickhouseclient/native.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -24,6 +25,7 @@ type NativeClientConfig struct {
 	Port             uint16
 	UserPasswordAuth *UserPasswordAuth
 	TLSConfig        *tls.Config
+	DialTimeout      time.Duration
 }
 
 func NewNativeClient(config NativeClientConfig) (ClickhouseClient, error) {
@@ -39,6 +41,10 @@ func NewNativeClient(config NativeClientConfig) (ClickhouseClient, error) {
 
 	options := clickhouse.Options{
 		Addr: []string{fmt.Sprintf("%s:%d", config.Host, config.Port)},
+	}
+
+	if config.DialTimeout > 0 {
+		options.DialTimeout = config.DialTimeout
 	}
 
 	if config.UserPasswordAuth != nil {

--- a/pkg/provider/model.go
+++ b/pkg/provider/model.go
@@ -12,6 +12,7 @@ type Model struct {
 	AuthConfig            AuthConfig   `tfsdk:"auth_config"`
 	TLSConfig             *TLSConfig   `tfsdk:"tls_config"`
 	ReadAfterWriteTimeout types.Int64  `tfsdk:"read_after_write_timeout"`
+	DialTimeout           types.Int64  `tfsdk:"dial_timeout"`
 }
 
 type AuthConfig struct {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -122,6 +122,13 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 					int64validator.AtLeast(1),
 				},
 			},
+			"dial_timeout": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Timeout in seconds for establishing connections to ClickHouse. Only applies to the native and nativesecure protocols. Useful when the ClickHouse instance takes time to start up from an idle state.",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+			},
 		},
 	}
 }
@@ -198,12 +205,16 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 				}
 			}
 
-			clickhouseClient, err = clickhouseclient.NewNativeClient(clickhouseclient.NativeClientConfig{
+			nativeConfig := clickhouseclient.NativeClientConfig{
 				Host:             data.Host.ValueString(),
 				Port:             port,
 				UserPasswordAuth: auth,
 				TLSConfig:        nativeTLSConfig,
-			})
+			}
+			if !data.DialTimeout.IsNull() {
+				nativeConfig.DialTimeout = time.Duration(data.DialTimeout.ValueInt64()) * time.Second
+			}
+			clickhouseClient, err = clickhouseclient.NewNativeClient(nativeConfig)
 		case protocolHTTP:
 			fallthrough
 		case protocolHTTPS:
@@ -260,15 +271,13 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 				}
 			}
 
-			config := clickhouseclient.HTTPClientConfig{
+			clickhouseClient, err = clickhouseclient.NewHTTPClient(clickhouseclient.HTTPClientConfig{
 				Protocol:  protocol,
 				Host:      data.Host.ValueString(),
 				Port:      port,
 				BasicAuth: auth,
 				TLSConfig: tlsConfig,
-			}
-
-			clickhouseClient, err = clickhouseclient.NewHTTPClient(config)
+			})
 		}
 	}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+func TestProviderSchema_HasTimeoutAttribute(t *testing.T) {
+	p := &Provider{}
+
+	req := provider.SchemaRequest{}
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema returned errors: %v", resp.Diagnostics.Errors())
+	}
+
+	attr, ok := resp.Schema.Attributes["dial_timeout"]
+	if !ok {
+		t.Fatal("expected 'dial_timeout' attribute in provider schema, not found")
+	}
+
+	if attr.IsRequired() {
+		t.Error("'dial_timeout' attribute should be optional, not required")
+	}
+}
+
+func TestProviderSchema_HasReadAfterWriteTimeoutAttribute(t *testing.T) {
+	p := &Provider{}
+
+	req := provider.SchemaRequest{}
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema returned errors: %v", resp.Diagnostics.Errors())
+	}
+
+	if _, ok := resp.Schema.Attributes["read_after_write_timeout"]; !ok {
+		t.Fatal("expected 'read_after_write_timeout' attribute in provider schema, not found")
+	}
+}
+
+func TestProviderSchema_RequiredAttributes(t *testing.T) {
+	p := &Provider{}
+
+	req := provider.SchemaRequest{}
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema returned errors: %v", resp.Diagnostics.Errors())
+	}
+
+	required := []string{"protocol", "host", "port", "auth_config"}
+	for _, name := range required {
+		attr, ok := resp.Schema.Attributes[name]
+		if !ok {
+			t.Errorf("expected required attribute %q not found", name)
+			continue
+		}
+		if !attr.IsRequired() {
+			t.Errorf("attribute %q should be required", name)
+		}
+	}
+}


### PR DESCRIPTION
Adds optional `timeout` attribute to provider config, applied as dial timeout for native protocol and HTTP client timeout.

Improvement for https://github.com/ClickHouse/terraform-provider-clickhousedbops/issues/128