### PR TITLE
feat(grant_privilege): support GRANT CURRENT GRANTS(...)

### DIFF
--- a/docs/resources/grant_privilege.md
+++ b/docs/resources/grant_privilege.md
@@ -6,7 +6,7 @@ description: |-
   You can use the clickhousedbops_grant_privilege resource to grant privileges on databases and tables to either a clickhousedbops_user or a clickhousedbops_role.
   Please note that in order to grant privileges to all database and/or all tables, the database and/or table fields must be set to null, and not to "*".
   Known limitations:
-  Only a subset of privileges can be granted on ClickHouse cloud. For example the ALL privilege can't be granted. See https://clickhouse.com/docs/en/sql-reference/statements/grant#allIt's not possible to grant privileges using their alias name. The canonical name must be used.It's not possible to grant group of privileges. Please grant each member of the group individually instead.It's not possible to grant the same clickhousedbops_grant_privilege to both a clickhousedbops_user and a clickhousedbops_role using a single clickhousedbops_grant_privilege stanza. You can do that using two different stanzas, one with grantee_user_name and the other with grantee_role_name fields set.It's not possible to grant the same privilege (example 'SELECT') to multiple entities (for example tables) with a single stanza. You can do that my creating one stanza for each entity you want to grant privileges on.Importing clickhousedbops_grant_privilege resources into terraform is not supported.
+  On ClickHouse Cloud some broad privileges (for example ALL, or SELECT on *.*) can't be granted directly, because the admin user holds them but can't transfer them. Set current_grants = true to grant them via GRANT CURRENT GRANTS(...). See https://clickhouse.com/docs/en/sql-reference/statements/grant#allIt's not possible to grant privileges using their alias name. The canonical name must be used.A group of privileges (such as ALL) can't be granted directly: grant each member of the group individually, or set current_grants = true to copy the group from the grantor.It's not possible to grant the same clickhousedbops_grant_privilege to both a clickhousedbops_user and a clickhousedbops_role using a single clickhousedbops_grant_privilege stanza. You can do that using two different stanzas, one with grantee_user_name and the other with grantee_role_name fields set.It's not possible to grant the same privilege (example 'SELECT') to multiple entities (for example tables) with a single stanza. You can do that my creating one stanza for each entity you want to grant privileges on.Importing clickhousedbops_grant_privilege resources into terraform is not supported.
 ---
 
 # clickhousedbops_grant_privilege (Resource)
@@ -17,9 +17,9 @@ Please note that in order to grant privileges to all database and/or all tables,
 
 Known limitations:
 
-- Only a subset of privileges can be granted on ClickHouse cloud. For example the `ALL` privilege can't be granted. See https://clickhouse.com/docs/en/sql-reference/statements/grant#all
+- On ClickHouse Cloud some broad privileges (for example `ALL`, or `SELECT` on `*.*`) can't be granted directly, because the admin user holds them but can't transfer them. Set `current_grants = true` to grant them via `GRANT CURRENT GRANTS(...)`. See https://clickhouse.com/docs/en/sql-reference/statements/grant#all
 - It's not possible to grant privileges using their alias name. The canonical name must be used.
-- It's not possible to grant group of privileges. Please grant each member of the group individually instead.
+- A group of privileges (such as `ALL`) can't be granted directly: grant each member of the group individually, or set `current_grants = true` to copy the group from the grantor.
 - It's not possible to grant the same `clickhousedbops_grant_privilege` to both a `clickhousedbops_user` and a `clickhousedbops_role` using a single `clickhousedbops_grant_privilege` stanza. You can do that using two different stanzas, one with `grantee_user_name` and the other with `grantee_role_name` fields set.
 - It's not possible to grant the same privilege (example 'SELECT') to multiple entities (for example tables) with a single stanza. You can do that my creating one stanza for each entity you want to grant privileges on.
 - Importing `clickhousedbops_grant_privilege` resources into terraform is not supported.
@@ -75,7 +75,7 @@ resource "clickhousedbops_grant_privilege" "user_admin" {
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
 - `column_name` (String) The name of the column in `table_name` to grant privilege on.
-- `current_grants` (Boolean) If true, emit `GRANT CURRENT GRANTS(...)` so the privilege is copied from the grantor's own grants instead of granted directly. Required on ClickHouse Cloud for broad privileges (e.g. `ALL`, or `SELECT` on `*.*`) that the admin user holds but cannot transfer directly. Note: the effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant is not reconciled.
+- `current_grants` (Boolean) If true, emit `GRANT CURRENT GRANTS(...)` so the privilege is copied from the grantor's own grants instead of granted directly. Required on ClickHouse Cloud for broad privileges (e.g. `ALL`, or `SELECT` on `*.*`) that the admin user holds but cannot transfer directly. Note: the effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant is not reconciled. On destroy the privilege is revoked in full from the grantee on the target.
 - `database_name` (String) The name of the database to grant privilege on. Defaults to all databases if left null
 - `grant_option` (Boolean) If true, the grantee will be able to grant the same privileges to others.
 - `grantee_role_name` (String) Name of the `role` to grant privileges to.

--- a/docs/resources/grant_privilege.md
+++ b/docs/resources/grant_privilege.md
@@ -36,6 +36,23 @@ resource "clickhousedbops_grant_privilege" "grant" {
   grant_option      = true
 }
 
+# On ClickHouse Cloud, broad grants the default admin holds but cannot transfer
+# directly (e.g. SELECT on every database) must be copied with CURRENT GRANTS.
+resource "clickhousedbops_grant_privilege" "read_everything" {
+  privilege_name    = "SELECT"
+  grantee_user_name = "my_monitoring_user"
+  current_grants    = true
+}
+
+# Granting ALL on a database directly fails on ClickHouse Cloud with error 497;
+# current_grants copies it from the admin instead.
+resource "clickhousedbops_grant_privilege" "full_db_access" {
+  privilege_name    = "ALL"
+  database_name     = "mydb"
+  grantee_role_name = "my_role"
+  current_grants    = true
+}
+
 # Access-management privileges (CREATE/ALTER/DROP USER and ROLE) are granted
 # globally, so database_name and table_name are left null (granted on *.*).
 resource "clickhousedbops_grant_privilege" "user_admin" {
@@ -58,6 +75,7 @@ resource "clickhousedbops_grant_privilege" "user_admin" {
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
 - `column_name` (String) The name of the column in `table_name` to grant privilege on.
+- `current_grants` (Boolean) If true, emit `GRANT CURRENT GRANTS(...)` so the privilege is copied from the grantor's own grants instead of granted directly. Required on ClickHouse Cloud for broad privileges (e.g. `ALL`, or `SELECT` on `*.*`) that the admin user holds but cannot transfer directly. Note: the effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant is not reconciled.
 - `database_name` (String) The name of the database to grant privilege on. Defaults to all databases if left null
 - `grant_option` (Boolean) If true, the grantee will be able to grant the same privileges to others.
 - `grantee_role_name` (String) Name of the `role` to grant privileges to.

--- a/examples/resources/clickhousedbops_grant_privilege/resource.tf
+++ b/examples/resources/clickhousedbops_grant_privilege/resource.tf
@@ -7,6 +7,23 @@ resource "clickhousedbops_grant_privilege" "grant" {
   grant_option      = true
 }
 
+# On ClickHouse Cloud, broad grants the default admin holds but cannot transfer
+# directly (e.g. SELECT on every database) must be copied with CURRENT GRANTS.
+resource "clickhousedbops_grant_privilege" "read_everything" {
+  privilege_name    = "SELECT"
+  grantee_user_name = "my_monitoring_user"
+  current_grants    = true
+}
+
+# Granting ALL on a database directly fails on ClickHouse Cloud with error 497;
+# current_grants copies it from the admin instead.
+resource "clickhousedbops_grant_privilege" "full_db_access" {
+  privilege_name    = "ALL"
+  database_name     = "mydb"
+  grantee_role_name = "my_role"
+  current_grants    = true
+}
+
 # Access-management privileges (CREATE/ALTER/DROP USER and ROLE) are granted
 # globally, so database_name and table_name are left null (granted on *.*).
 resource "clickhousedbops_grant_privilege" "user_admin" {

--- a/examples/tests/grantprivilege/main.tf
+++ b/examples/tests/grantprivilege/main.tf
@@ -62,6 +62,8 @@ resource "clickhousedbops_grant_privilege" "grant_sources2" {
 }
 
 resource "clickhousedbops_grant_privilege" "grant_current_grants_to_role" {
+  count = (var.cluster_name == null) ? 1 : 0
+
   cluster_name      = var.cluster_name
   privilege_name    = "SELECT"
   grantee_role_name = clickhousedbops_role.reader.name

--- a/examples/tests/grantprivilege/main.tf
+++ b/examples/tests/grantprivilege/main.tf
@@ -61,6 +61,13 @@ resource "clickhousedbops_grant_privilege" "grant_sources2" {
   grant_option      = false
 }
 
+resource "clickhousedbops_grant_privilege" "grant_current_grants_to_role" {
+  cluster_name      = var.cluster_name
+  privilege_name    = "SELECT"
+  grantee_role_name = clickhousedbops_role.reader.name
+  current_grants    = true
+}
+
 resource "clickhousedbops_grant_privilege" "grant_user_admin_to_role" {
   for_each          = toset(["CREATE USER", "DROP USER", "ALTER USER", "CREATE ROLE"])
   cluster_name      = var.cluster_name

--- a/internal/dbops/grantprivilege.go
+++ b/internal/dbops/grantprivilege.go
@@ -47,6 +47,10 @@ type GrantPrivilege struct {
 	// into its children in system.grants instead of storing a single parent row.
 	// Setting this field allows the matcher to find the grant in either case.
 	ExpandedAccessTypes []string `json:"-"`
+	// CurrentGrants emits `GRANT CURRENT GRANTS(... ON ...)`, copying the grantor's own
+	// privileges. Needed on ClickHouse Cloud for broad grants the default admin holds but
+	// cannot transfer directly (see #190).
+	CurrentGrants bool `json:"-"`
 }
 
 // AsGrant projects the grant onto the neutral grants.Grant used for coverage checks.
@@ -81,6 +85,7 @@ func (i *impl) GrantPrivilege(ctx context.Context, grantPrivilege GrantPrivilege
 		WithColumn(grantPrivilege.ColumnName).
 		WithGrantOption(grantPrivilege.GrantOption).
 		WithCluster(clusterName).
+		WithCurrentGrants(grantPrivilege.CurrentGrants).
 		Build()
 	if err != nil {
 		return nil, errors.WithMessage(err, "error building query")

--- a/internal/querybuilder/grantprivilege.go
+++ b/internal/querybuilder/grantprivilege.go
@@ -15,16 +15,18 @@ type GrantPrivilegeQueryBuilder interface {
 	WithColumn(*string) GrantPrivilegeQueryBuilder
 	WithGrantOption(bool) GrantPrivilegeQueryBuilder
 	WithCluster(*string) GrantPrivilegeQueryBuilder
+	WithCurrentGrants(bool) GrantPrivilegeQueryBuilder
 }
 
 type grantPrivilegeQueryBuilder struct {
-	accessType  string
-	to          string
-	database    *string
-	table       *string
-	column      *string
-	grantOption bool
-	clusterName *string
+	accessType    string
+	to            string
+	database      *string
+	table         *string
+	column        *string
+	grantOption   bool
+	clusterName   *string
+	currentGrants bool
 }
 
 func GrantPrivilege(accessType string, to string) GrantPrivilegeQueryBuilder {
@@ -59,6 +61,11 @@ func (q *grantPrivilegeQueryBuilder) WithGrantOption(grantOption bool) GrantPriv
 	return q
 }
 
+func (q *grantPrivilegeQueryBuilder) WithCurrentGrants(currentGrants bool) GrantPrivilegeQueryBuilder {
+	q.currentGrants = currentGrants
+	return q
+}
+
 func (q *grantPrivilegeQueryBuilder) Build() (string, error) {
 	if q.accessType == "" {
 		return "", errors.New("AccessType cannot be empty")
@@ -76,25 +83,32 @@ func (q *grantPrivilegeQueryBuilder) Build() (string, error) {
 	}
 
 	// Privilege
+	var privilege string
 	if q.column != nil && *q.column != "" {
-		tokens = append(tokens, fmt.Sprintf("%s(%s)", q.accessType, backtick(*q.column)))
+		privilege = fmt.Sprintf("%s(%s)", q.accessType, backtick(*q.column))
 	} else {
-		tokens = append(tokens, q.accessType)
+		privilege = q.accessType
 	}
 
 	// Target database/table
-	{
-		tokens = append(tokens, "ON")
-
-		if q.database != nil {
-			if q.table != nil {
-				tokens = append(tokens, fmt.Sprintf("%s.%s", identifierOrPattern(*q.database), identifierOrPattern(*q.table)))
-			} else {
-				tokens = append(tokens, fmt.Sprintf("%s.*", identifierOrPattern(*q.database)))
-			}
+	var target string
+	if q.database != nil {
+		if q.table != nil {
+			target = fmt.Sprintf("%s.%s", identifierOrPattern(*q.database), identifierOrPattern(*q.table))
 		} else {
-			tokens = append(tokens, "*.*")
+			target = fmt.Sprintf("%s.*", identifierOrPattern(*q.database))
 		}
+	} else {
+		target = "*.*"
+	}
+
+	// CURRENT GRANTS copies the grantor's own privileges. ClickHouse Cloud requires it for
+	// broad grants (e.g. ALL, SELECT ON *.*) the default admin holds but cannot transfer
+	// directly. See ClickHouse/terraform-provider-clickhousedbops#190.
+	if q.currentGrants {
+		tokens = append(tokens, fmt.Sprintf("CURRENT GRANTS(%s ON %s)", privilege, target))
+	} else {
+		tokens = append(tokens, privilege, "ON", target)
 	}
 
 	// Grantee

--- a/internal/querybuilder/grantprivilege_test.go
+++ b/internal/querybuilder/grantprivilege_test.go
@@ -54,6 +54,30 @@ func Test_grantPrivilegeQueryBuilder(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Current grants ALL on all",
+			builder: GrantPrivilege("ALL", "user1").WithCurrentGrants(true),
+			want:    "GRANT CURRENT GRANTS(ALL ON *.*) TO `user1`;",
+			wantErr: false,
+		},
+		{
+			name:    "Current grants SELECT on all",
+			builder: GrantPrivilege("SELECT", "user1").WithCurrentGrants(true),
+			want:    "GRANT CURRENT GRANTS(SELECT ON *.*) TO `user1`;",
+			wantErr: false,
+		},
+		{
+			name:    "Current grants on database with grant option",
+			builder: GrantPrivilege("SELECT", "role1").WithCurrentGrants(true).WithDatabase(strptr("db1")).WithGrantOption(true),
+			want:    "GRANT CURRENT GRANTS(SELECT ON `db1`.*) TO `role1` WITH GRANT OPTION;",
+			wantErr: false,
+		},
+		{
+			name:    "Current grants false is unchanged",
+			builder: GrantPrivilege("SELECT", "user1").WithCurrentGrants(false),
+			want:    "GRANT SELECT ON *.* TO `user1`;",
+			wantErr: false,
+		},
+		{
 			name:    "Access management CREATE USER on all",
 			builder: GrantPrivilege("CREATE USER", "admin"),
 			want:    "GRANT CREATE USER ON *.* TO `admin`;",

--- a/internal/querybuilder/grantprivilege_test.go
+++ b/internal/querybuilder/grantprivilege_test.go
@@ -72,6 +72,12 @@ func Test_grantPrivilegeQueryBuilder(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Current grants on single column",
+			builder: GrantPrivilege("SELECT", "user1").WithCurrentGrants(true).WithDatabase(strptr("db1")).WithTable(strptr("tbl1")).WithColumn(strptr("test")),
+			want:    "GRANT CURRENT GRANTS(SELECT(`test`) ON `db1`.`tbl1`) TO `user1`;",
+			wantErr: false,
+		},
+		{
 			name:    "Current grants false is unchanged",
 			builder: GrantPrivilege("SELECT", "user1").WithCurrentGrants(false),
 			want:    "GRANT SELECT ON *.* TO `user1`;",

--- a/pkg/resource/grantprivilege/grantprivilege.go
+++ b/pkg/resource/grantprivilege/grantprivilege.go
@@ -181,6 +181,15 @@ func validateScope(config GrantPrivilege, diags *diag.Diagnostics) {
 		return
 	}
 
+	// GRANT CURRENT GRANTS cannot be executed ON CLUSTER, so current_grants and cluster_name are mutually exclusive.
+	if config.CurrentGrants.ValueBool() && !config.ClusterName.IsUnknown() && config.ClusterName.ValueString() != "" {
+		diags.AddAttributeError(
+			path.Root("current_grants"),
+			"Invalid Grant Privilege",
+			"'current_grants' cannot be used together with 'cluster_name': GRANT CURRENT GRANTS cannot be executed ON CLUSTER.",
+		)
+	}
+
 	upstrGrts := grants.Parsed()
 
 	// Aliases must be granted using their canonical name.

--- a/pkg/resource/grantprivilege/grantprivilege.go
+++ b/pkg/resource/grantprivilege/grantprivilege.go
@@ -157,7 +157,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
-				Description: "If true, emit `GRANT CURRENT GRANTS(...)` so the privilege is copied from the grantor's own grants instead of granted directly. Required on ClickHouse Cloud for broad privileges (e.g. `ALL`, or `SELECT` on `*.*`) that the admin user holds but cannot transfer directly. Note: the effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant is not reconciled.",
+				Description: "If true, emit `GRANT CURRENT GRANTS(...)` so the privilege is copied from the grantor's own grants instead of granted directly. Required on ClickHouse Cloud for broad privileges (e.g. `ALL`, or `SELECT` on `*.*`) that the admin user holds but cannot transfer directly. Note: the effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant is not reconciled. On destroy the privilege is revoked in full from the grantee on the target.",
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),
 				},
@@ -223,13 +223,6 @@ func validateScope(config GrantPrivilege, diags *diag.Diagnostics) {
 			"Invalid Grant Privilege",
 			fmt.Sprintf("%q must be null when 'privilege_name' is %q", attrName, config.Privilege.ValueString()),
 		)
-	}
-
-	// CURRENT GRANTS targets the grantor's own privileges, so scope-based field requirements
-	// (e.g. a GLOBAL privilege needing a null database_name) do not apply: the target can
-	// legitimately be *.* for any privilege. Aliases and unsupported privileges stay blocked.
-	if config.CurrentGrants.ValueBool() {
-		return
 	}
 
 	checkAttr("database_name", attrs.Database, allAttrs.Database, !config.Database.IsNull())

--- a/pkg/resource/grantprivilege/grantprivilege.go
+++ b/pkg/resource/grantprivilege/grantprivilege.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -152,6 +153,15 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 					boolplanmodifier.RequiresReplace(),
 				},
 			},
+			"current_grants": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "If true, emit `GRANT CURRENT GRANTS(...)` so the privilege is copied from the grantor's own grants instead of granted directly. Required on ClickHouse Cloud for broad privileges (e.g. `ALL`, or `SELECT` on `*.*`) that the admin user holds but cannot transfer directly. Note: the effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant is not reconciled.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 		MarkdownDescription: grantPrivilegeDescription,
 	}
@@ -213,6 +223,13 @@ func validateScope(config GrantPrivilege, diags *diag.Diagnostics) {
 			"Invalid Grant Privilege",
 			fmt.Sprintf("%q must be null when 'privilege_name' is %q", attrName, config.Privilege.ValueString()),
 		)
+	}
+
+	// CURRENT GRANTS targets the grantor's own privileges, so scope-based field requirements
+	// (e.g. a GLOBAL privilege needing a null database_name) do not apply: the target can
+	// legitimately be *.* for any privilege. Aliases and unsupported privileges stay blocked.
+	if config.CurrentGrants.ValueBool() {
+		return
 	}
 
 	checkAttr("database_name", attrs.Database, allAttrs.Database, !config.Database.IsNull())
@@ -325,6 +342,8 @@ This is a configuration error that prevents further actions. Please note that th
 	}
 
 	state := toState(*createdGrant, plan.ClusterName)
+	// current_grants is config-only: ClickHouse does not return it, so carry it forward.
+	state.CurrentGrants = plan.CurrentGrants
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -354,6 +373,8 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 
 	if grant != nil {
 		newState := toState(*grant, state.ClusterName)
+		// current_grants is config-only: ClickHouse does not return it, so carry it forward.
+		newState.CurrentGrants = state.CurrentGrants
 		diags = resp.State.Set(ctx, &newState)
 		resp.Diagnostics.Append(diags...)
 	} else {

--- a/pkg/resource/grantprivilege/grantprivilege.md
+++ b/pkg/resource/grantprivilege/grantprivilege.md
@@ -4,9 +4,9 @@ Please note that in order to grant privileges to all database and/or all tables,
 
 Known limitations:
 
-- Only a subset of privileges can be granted on ClickHouse cloud. For example the `ALL` privilege can't be granted. See https://clickhouse.com/docs/en/sql-reference/statements/grant#all
+- On ClickHouse Cloud some broad privileges (for example `ALL`, or `SELECT` on `*.*`) can't be granted directly, because the admin user holds them but can't transfer them. Set `current_grants = true` to grant them via `GRANT CURRENT GRANTS(...)`. See https://clickhouse.com/docs/en/sql-reference/statements/grant#all
 - It's not possible to grant privileges using their alias name. The canonical name must be used.
-- It's not possible to grant group of privileges. Please grant each member of the group individually instead.
+- A group of privileges (such as `ALL`) can't be granted directly: grant each member of the group individually, or set `current_grants = true` to copy the group from the grantor.
 - It's not possible to grant the same `clickhousedbops_grant_privilege` to both a `clickhousedbops_user` and a `clickhousedbops_role` using a single `clickhousedbops_grant_privilege` stanza. You can do that using two different stanzas, one with `grantee_user_name` and the other with `grantee_role_name` fields set.
 - It's not possible to grant the same privilege (example 'SELECT') to multiple entities (for example tables) with a single stanza. You can do that my creating one stanza for each entity you want to grant privileges on.
 - Importing `clickhousedbops_grant_privilege` resources into terraform is not supported.

--- a/pkg/resource/grantprivilege/model.go
+++ b/pkg/resource/grantprivilege/model.go
@@ -16,6 +16,7 @@ type GrantPrivilege struct {
 	GranteeUserName types.String `tfsdk:"grantee_user_name"`
 	GranteeRoleName types.String `tfsdk:"grantee_role_name"`
 	GrantOption     types.Bool   `tfsdk:"grant_option"`
+	CurrentGrants   types.Bool   `tfsdk:"current_grants"`
 }
 
 func (g GrantPrivilege) toGrant() dbops.GrantPrivilege {
@@ -28,6 +29,7 @@ func (g GrantPrivilege) toGrant() dbops.GrantPrivilege {
 		GranteeUserName:     g.GranteeUserName.ValueStringPointer(),
 		GranteeRoleName:     g.GranteeRoleName.ValueStringPointer(),
 		GrantOption:         g.GrantOption.ValueBool(),
+		CurrentGrants:       g.CurrentGrants.ValueBool(),
 	}
 }
 


### PR DESCRIPTION
## Problem

- On ClickHouse Cloud, granting `ALL` (or `SELECT ON *.*`) fails with error 497: the `default` admin holds the privilege but can't transfer it directly (#190).
- ClickHouse's own error message suggests `GRANT CURRENT GRANTS(...)`, but the provider can't emit it.

## Solution

- A `current_grants` flag on `clickhousedbops_grant_privilege` that grants `CURRENT GRANTS(<privilege> ON <target>)`, copying the privilege from the grantor.

```hcl
# The config from #190 that failed with error 497, now working.
resource "clickhousedbops_grant_privilege" "full_db_access" {
  privilege_name    = "ALL"
  database_name     = "mydb"
  grantee_role_name = "my_role"
  current_grants    = true
}
```

## Implementation details

- Effective grants depend on what the grantor holds at apply time, so drift on a `current_grants` grant isn't reconciled (documented on the attribute).

Fixes #190
