### PR TITLE
fix(grant_privilege): migrate current_grants state

### DIFF
--- a/pkg/resource/grantprivilege/grantprivilege.go
+++ b/pkg/resource/grantprivilege/grantprivilege.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/dbops"
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/grants"
@@ -27,6 +28,7 @@ var grantPrivilegeDescription string
 var (
 	_ resource.Resource                   = &Resource{}
 	_ resource.ResourceWithConfigure      = &Resource{}
+	_ resource.ResourceWithUpgradeState   = &Resource{}
 	_ resource.ResourceWithValidateConfig = &Resource{}
 )
 
@@ -45,6 +47,10 @@ func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, res
 }
 
 func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceSchema(1)
+}
+
+func resourceSchema(version int64) schema.Schema {
 	validPrivileges := make([]string, 0)
 
 	upstrGrts := grants.Parsed()
@@ -61,7 +67,8 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 		validPrivileges = append(validPrivileges, groupName)
 	}
 
-	resp.Schema = schema.Schema{
+	return schema.Schema{
+		Version: version,
 		Attributes: map[string]schema.Attribute{
 			"cluster_name": schema.StringAttribute{
 				Optional:    true,
@@ -180,6 +187,29 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			},
 		},
 		MarkdownDescription: grantPrivilegeDescription,
+	}
+}
+
+func (r *Resource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	priorSchema := resourceSchema(0)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &priorSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state GrantPrivilege
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				if state.CurrentGrants.IsNull() {
+					state.CurrentGrants = types.BoolValue(false)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			},
+		},
 	}
 }
 

--- a/pkg/resource/grantprivilege/grantprivilege.go
+++ b/pkg/resource/grantprivilege/grantprivilege.go
@@ -191,6 +191,11 @@ func resourceSchema(version int64) schema.Schema {
 }
 
 func (r *Resource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	// Reusing the current schema as the version 0 prior schema is safe:
+	// attributes missing from an old raw state (e.g. `current_grants` before
+	// v1.11.0) are decoded as null. Both pre-v1.11.0 and v1.11.0 states are
+	// version 0; only v1.11.0 states may already carry a `current_grants`
+	// value, which is preserved as-is below.
 	priorSchema := resourceSchema(0)
 
 	return map[int64]resource.StateUpgrader{

--- a/pkg/resource/grantprivilege/state_upgrade_test.go
+++ b/pkg/resource/grantprivilege/state_upgrade_test.go
@@ -1,0 +1,63 @@
+package grantprivilege
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeState(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		currentGrants types.Bool
+		expected      bool
+	}{
+		"defaults state from before current_grants to false": {
+			currentGrants: types.BoolNull(),
+			expected:      false,
+		},
+		"preserves current_grants from version 1.11 state": {
+			currentGrants: types.BoolValue(true),
+			expected:      true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			r := &Resource{}
+			upgrader := r.UpgradeState(ctx)[0]
+			require.NotNil(t, upgrader.PriorSchema)
+
+			priorState := tfsdk.State{Schema: *upgrader.PriorSchema}
+			diags := priorState.Set(ctx, GrantPrivilege{
+				Privilege:       types.StringValue("SELECT"),
+				GranteeRoleName: types.StringValue("reader"),
+				CurrentGrants:   test.currentGrants,
+			})
+			require.False(t, diags.HasError(), diags.Errors())
+
+			schemaResponse := resource.SchemaResponse{}
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+			require.Equal(t, int64(1), schemaResponse.Schema.Version)
+
+			response := resource.UpgradeStateResponse{
+				State: tfsdk.State{Schema: schemaResponse.Schema},
+			}
+			upgrader.StateUpgrader(ctx, resource.UpgradeStateRequest{State: &priorState}, &response)
+			require.False(t, response.Diagnostics.HasError(), response.Diagnostics.Errors())
+
+			var state GrantPrivilege
+			diags = response.State.Get(ctx, &state)
+			require.False(t, diags.HasError(), diags.Errors())
+			require.Equal(t, test.expected, state.CurrentGrants.ValueBool())
+		})
+	}
+}

--- a/pkg/resource/grantprivilege/state_upgrade_test.go
+++ b/pkg/resource/grantprivilege/state_upgrade_test.go
@@ -58,6 +58,10 @@ func TestUpgradeState(t *testing.T) {
 			diags = response.State.Get(ctx, &state)
 			require.False(t, diags.HasError(), diags.Errors())
 			require.Equal(t, test.expected, state.CurrentGrants.ValueBool())
+
+			// Other fields must round-trip unchanged through the upgrader.
+			require.Equal(t, types.StringValue("SELECT"), state.Privilege)
+			require.Equal(t, types.StringValue("reader"), state.GranteeRoleName)
 		})
 	}
 }


### PR DESCRIPTION
v1.11.0 introduced `current_grants` with a default of `false` and `RequiresReplace`. Existing states have no value for this attribute, causing every grant resource to be replaced and temporarily revoked.

This adds a schema migration that:

- defaults missing `current_grants` state to `false`
- preserves values already written by v1.11.0
- avoids unnecessary revoke/re-grant operations

Tests cover both legacy and v1.11.0 state.

Tested with:

- `go test ./...`
- `golangci-lint run --allow-serial-runners`