### PR TITLE
fix(user): migrate legacy password fields to the auth block in place

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -40,6 +40,25 @@ description: |-
   for backwards compatibility and behave as a single sha256_hash method. They compose additively with
   the auth block, so existing configurations keep working — but prefer the auth.sha256_hash block
   for new ones. Changing a legacy password field replaces the user.
+  To migrate, replace the legacy fields with an auth.sha256_hash block carrying the same hash:
+  that plans as an in-place update (the configured methods are re-asserted with ALTER USER),
+  not a replacement, so grants and dependent resources are untouched.
+  
+  resource "clickhousedbops_user" "example" {
+    name = "example"
+  
+    # Before (deprecated):
+    # password_sha256_hash_wo         = sha256("changeme")
+    # password_sha256_hash_wo_version = 1
+  
+    auth {
+      sha256_hash {
+        value_wo         = sha256("changeme")
+        value_wo_version = 1
+      }
+    }
+  }
+  
   Known limitations:
   
   Authentication values cannot be read back from ClickHouse, so external drift of a secret is not
@@ -97,6 +116,27 @@ Supported method blocks: `no_password`, `plaintext_password`, `sha256_password`,
 for backwards compatibility and behave as a single `sha256_hash` method. They compose additively with
 the `auth` block, so existing configurations keep working — but prefer the `auth.sha256_hash` block
 for new ones. Changing a legacy password field replaces the user.
+
+To migrate, replace the legacy fields with an `auth.sha256_hash` block carrying the same hash:
+that plans as an in-place update (the configured methods are re-asserted with `ALTER USER`),
+not a replacement, so grants and dependent resources are untouched.
+
+```terraform
+resource "clickhousedbops_user" "example" {
+  name = "example"
+
+  # Before (deprecated):
+  # password_sha256_hash_wo         = sha256("changeme")
+  # password_sha256_hash_wo_version = 1
+
+  auth {
+    sha256_hash {
+      value_wo         = sha256("changeme")
+      value_wo_version = 1
+    }
+  }
+}
+```
 
 Known limitations:
 
@@ -159,9 +199,9 @@ resource "clickhousedbops_user" "john" {
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
 - `host_ips` (Set of String) IP addresses from which the user is allowed to connect. If not specified, user can connect from any host.
-- `password_sha256_hash` (String, Sensitive, Deprecated) SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field will replace the user.
+- `password_sha256_hash` (String, Sensitive, Deprecated) SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field will replace the user, except removing it in favor of an auth block, which updates the user in place.
 - `password_sha256_hash_wo` (String, Sensitive, Deprecated, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu >= 1.11. Conflicts with password_sha256_hash.
-- `password_sha256_hash_wo_version` (Number, Deprecated) Version of the password_sha256_hash_wo field. Bump this value to require a force update of the password on the user.
+- `password_sha256_hash_wo_version` (Number, Deprecated) Version of the password_sha256_hash_wo field. Bump this value to require a force update of the password on the user. Removing it together with password_sha256_hash_wo in favor of an auth block updates the user in place.
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -39,26 +39,8 @@ description: |-
   password_sha256_hash / password_sha256_hash_wo (with password_sha256_hash_wo_version) are kept
   for backwards compatibility and behave as a single sha256_hash method. They compose additively with
   the auth block, so existing configurations keep working — but prefer the auth.sha256_hash block
-  for new ones. Changing a legacy password field replaces the user.
-  To migrate, replace the legacy fields with an auth.sha256_hash block carrying the same hash:
-  that plans as an in-place update (the configured methods are re-asserted with ALTER USER),
-  not a replacement, so grants and dependent resources are untouched.
-  
-  resource "clickhousedbops_user" "example" {
-    name = "example"
-  
-    # Before (deprecated):
-    # password_sha256_hash_wo         = sha256("changeme")
-    # password_sha256_hash_wo_version = 1
-  
-    auth {
-      sha256_hash {
-        value_wo         = sha256("changeme")
-        value_wo_version = 1
-      }
-    }
-  }
-  
+  for new ones. Replacing them with an auth.sha256_hash block carrying the same hash updates the
+  user in place.
   Known limitations:
   
   Authentication values cannot be read back from ClickHouse, so external drift of a secret is not
@@ -115,28 +97,8 @@ Supported method blocks: `no_password`, `plaintext_password`, `sha256_password`,
 `password_sha256_hash` / `password_sha256_hash_wo` (with `password_sha256_hash_wo_version`) are kept
 for backwards compatibility and behave as a single `sha256_hash` method. They compose additively with
 the `auth` block, so existing configurations keep working — but prefer the `auth.sha256_hash` block
-for new ones. Changing a legacy password field replaces the user.
-
-To migrate, replace the legacy fields with an `auth.sha256_hash` block carrying the same hash:
-that plans as an in-place update (the configured methods are re-asserted with `ALTER USER`),
-not a replacement, so grants and dependent resources are untouched.
-
-```terraform
-resource "clickhousedbops_user" "example" {
-  name = "example"
-
-  # Before (deprecated):
-  # password_sha256_hash_wo         = sha256("changeme")
-  # password_sha256_hash_wo_version = 1
-
-  auth {
-    sha256_hash {
-      value_wo         = sha256("changeme")
-      value_wo_version = 1
-    }
-  }
-}
-```
+for new ones. Replacing them with an `auth.sha256_hash` block carrying the same hash updates the
+user in place.
 
 Known limitations:
 
@@ -199,9 +161,9 @@ resource "clickhousedbops_user" "john" {
 This field must be left null when using a ClickHouse Cloud cluster.
 When using a self hosted ClickHouse instance, this field should only be set when there is more than one replica and you are not using 'replicated' storage for user_directory.
 - `host_ips` (Set of String) IP addresses from which the user is allowed to connect. If not specified, user can connect from any host.
-- `password_sha256_hash` (String, Sensitive, Deprecated) SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field will replace the user, except removing it in favor of an auth block, which updates the user in place.
+- `password_sha256_hash` (String, Sensitive, Deprecated) SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field update the user in place.
 - `password_sha256_hash_wo` (String, Sensitive, Deprecated, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu >= 1.11. Conflicts with password_sha256_hash.
-- `password_sha256_hash_wo_version` (Number, Deprecated) Version of the password_sha256_hash_wo field. Bump this value to require a force update of the password on the user. Removing it together with password_sha256_hash_wo in favor of an auth block updates the user in place.
+- `password_sha256_hash_wo_version` (Number, Deprecated) Version of the password_sha256_hash_wo field. Bump this value to update the password on the user.
 
 ### Read-Only
 

--- a/pkg/resource/user/model.go
+++ b/pkg/resource/user/model.go
@@ -31,6 +31,26 @@ type AuthModel struct {
 	Kerberos           []KerberosModel       `tfsdk:"kerberos"`
 }
 
+// hasMethods reports whether at least one authentication method is declared.
+func (a *AuthModel) hasMethods() bool {
+	if a == nil {
+		return false
+	}
+	return a.NoPassword != nil ||
+		len(a.PlaintextPassword) > 0 ||
+		len(a.Sha256Password) > 0 ||
+		len(a.Sha256Hash) > 0 ||
+		len(a.DoubleSha1Password) > 0 ||
+		len(a.DoubleSha1Hash) > 0 ||
+		len(a.BcryptPassword) > 0 ||
+		len(a.BcryptHash) > 0 ||
+		len(a.SSLCertificate) > 0 ||
+		len(a.HTTP) > 0 ||
+		len(a.SSHKey) > 0 ||
+		len(a.LDAP) > 0 ||
+		len(a.Kerberos) > 0
+}
+
 // NoPasswordModel is an empty presence block: set when passwordless auth is desired.
 type NoPasswordModel struct{}
 

--- a/pkg/resource/user/model.go
+++ b/pkg/resource/user/model.go
@@ -31,26 +31,6 @@ type AuthModel struct {
 	Kerberos           []KerberosModel       `tfsdk:"kerberos"`
 }
 
-// hasMethods reports whether at least one authentication method is declared.
-func (a *AuthModel) hasMethods() bool {
-	if a == nil {
-		return false
-	}
-	return a.NoPassword != nil ||
-		len(a.PlaintextPassword) > 0 ||
-		len(a.Sha256Password) > 0 ||
-		len(a.Sha256Hash) > 0 ||
-		len(a.DoubleSha1Password) > 0 ||
-		len(a.DoubleSha1Hash) > 0 ||
-		len(a.BcryptPassword) > 0 ||
-		len(a.BcryptHash) > 0 ||
-		len(a.SSLCertificate) > 0 ||
-		len(a.HTTP) > 0 ||
-		len(a.SSHKey) > 0 ||
-		len(a.LDAP) > 0 ||
-		len(a.Kerberos) > 0
-}
-
 // NoPasswordModel is an empty presence block: set when passwordless auth is desired.
 type NoPasswordModel struct{}
 

--- a/pkg/resource/user/user.go
+++ b/pkg/resource/user/user.go
@@ -26,15 +26,12 @@ import (
 
 const legacyReplaceDescription = "Changing this attribute replaces the user, unless it is removed while an auth block is configured: that is the migration path from the deprecated password fields and is applied in place."
 
-// legacyFieldRemovedForAuth reports whether a legacy password attribute is being
-// removed from configuration while the auth block declares at least one method.
-// That is the migration path from the deprecated fields to auth: Update
-// re-asserts the configured methods, so no replacement is needed.
-func legacyFieldRemovedForAuth(ctx context.Context, planIsNull bool, stateIsNull bool, cfg tfsdk.Config) bool {
-	if !planIsNull || stateIsNull {
-		return false
-	}
-
+// configHasAuthMethods reports whether the configuration declares at least one
+// method in the auth block. A null plan value here means the legacy attribute is
+// being removed (RequiresReplaceIf only runs when plan and state differ), and
+// removal with auth methods configured is the migration path off the deprecated
+// fields: Update re-asserts the configured methods, so no replacement is needed.
+func configHasAuthMethods(ctx context.Context, cfg tfsdk.Config) bool {
 	var config User
 	if diags := cfg.Get(ctx, &config); diags.HasError() {
 		return false
@@ -90,7 +87,8 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIf(
 						func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-							resp.RequiresReplace = !legacyFieldRemovedForAuth(ctx, req.PlanValue.IsNull(), req.StateValue.IsNull(), req.Config)
+							migratingToAuth := req.PlanValue.IsNull() && configHasAuthMethods(ctx, req.Config)
+							resp.RequiresReplace = !migratingToAuth
 						},
 						legacyReplaceDescription, legacyReplaceDescription,
 					),
@@ -122,7 +120,8 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				PlanModifiers: []planmodifier.Int32{
 					int32planmodifier.RequiresReplaceIf(
 						func(ctx context.Context, req planmodifier.Int32Request, resp *int32planmodifier.RequiresReplaceIfFuncResponse) {
-							resp.RequiresReplace = !legacyFieldRemovedForAuth(ctx, req.PlanValue.IsNull(), req.StateValue.IsNull(), req.Config)
+							migratingToAuth := req.PlanValue.IsNull() && configHasAuthMethods(ctx, req.Config)
+							resp.RequiresReplace = !migratingToAuth
 						},
 						legacyReplaceDescription, legacyReplaceDescription,
 					),

--- a/pkg/resource/user/user.go
+++ b/pkg/resource/user/user.go
@@ -13,32 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/dbops"
 )
-
-const legacyReplaceDescription = "Changing this attribute replaces the user, unless it is removed while an auth block is configured: that is the migration path from the deprecated password fields and is applied in place."
-
-// configHasAuthMethods reports whether the configuration declares at least one
-// method in the auth block. A null plan value here means the legacy attribute is
-// being removed (RequiresReplaceIf only runs when plan and state differ), and
-// removal with auth methods configured is the migration path off the deprecated
-// fields: Update re-asserts the configured methods, so no replacement is needed.
-func configHasAuthMethods(ctx context.Context, cfg tfsdk.Config) bool {
-	var config User
-	if diags := cfg.Get(ctx, &config); diags.HasError() {
-		return false
-	}
-
-	return config.Auth.hasMethods()
-}
 
 //go:embed user.md
 var userResourceDescription string
@@ -83,16 +65,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"password_sha256_hash": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field will replace the user, except removing it in favor of an auth block, which updates the user in place.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIf(
-						func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-							migratingToAuth := req.PlanValue.IsNull() && configHasAuthMethods(ctx, req.Config)
-							resp.RequiresReplace = !migratingToAuth
-						},
-						legacyReplaceDescription, legacyReplaceDescription,
-					),
-				},
+				Description: "SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field update the user in place.",
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-fA-F0-9]{64}$`), "password_sha256_hash must be a valid SHA256 hash"),
 					stringvalidator.ConflictsWith(path.MatchRoot("password_sha256_hash_wo")),
@@ -103,9 +76,6 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				Optional:    true,
 				Description: "SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu >= 1.11. Conflicts with password_sha256_hash.",
 				Sensitive:   true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-fA-F0-9]{64}$`), "password_sha256_hash must be a valid SHA256 hash"),
 					stringvalidator.AlsoRequires(path.MatchRoot("password_sha256_hash_wo_version")),
@@ -116,16 +86,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			},
 			"password_sha256_hash_wo_version": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Version of the password_sha256_hash_wo field. Bump this value to require a force update of the password on the user. Removing it together with password_sha256_hash_wo in favor of an auth block updates the user in place.",
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.RequiresReplaceIf(
-						func(ctx context.Context, req planmodifier.Int32Request, resp *int32planmodifier.RequiresReplaceIfFuncResponse) {
-							migratingToAuth := req.PlanValue.IsNull() && configHasAuthMethods(ctx, req.Config)
-							resp.RequiresReplace = !migratingToAuth
-						},
-						legacyReplaceDescription, legacyReplaceDescription,
-					),
-				},
+				Description: "Version of the password_sha256_hash_wo field. Bump this value to update the password on the user.",
 				Validators: []validator.Int32{
 					int32validator.AlsoRequires(path.MatchRoot("password_sha256_hash_wo")),
 				},

--- a/pkg/resource/user/user.go
+++ b/pkg/resource/user/user.go
@@ -18,10 +18,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/ClickHouse/terraform-provider-clickhousedbops/internal/dbops"
 )
+
+const legacyReplaceDescription = "Changing this attribute replaces the user, unless it is removed while an auth block is configured: that is the migration path from the deprecated password fields and is applied in place."
+
+// legacyFieldRemovedForAuth reports whether a legacy password attribute is being
+// removed from configuration while the auth block declares at least one method.
+// That is the migration path from the deprecated fields to auth: Update
+// re-asserts the configured methods, so no replacement is needed.
+func legacyFieldRemovedForAuth(ctx context.Context, planIsNull bool, stateIsNull bool, cfg tfsdk.Config) bool {
+	if !planIsNull || stateIsNull {
+		return false
+	}
+
+	var config User
+	if diags := cfg.Get(ctx, &config); diags.HasError() {
+		return false
+	}
+
+	return config.Auth.hasMethods()
+}
 
 //go:embed user.md
 var userResourceDescription string
@@ -66,9 +86,14 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"password_sha256_hash": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field will replace the user.",
+				Description: "SHA256 hash of the password to be set for the user. Use this for Terraform/OpenTofu < 1.11. Conflicts with password_sha256_hash_wo. Changes to this field will replace the user, except removing it in favor of an auth block, which updates the user in place.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.RequiresReplaceIf(
+						func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+							resp.RequiresReplace = !legacyFieldRemovedForAuth(ctx, req.PlanValue.IsNull(), req.StateValue.IsNull(), req.Config)
+						},
+						legacyReplaceDescription, legacyReplaceDescription,
+					),
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-fA-F0-9]{64}$`), "password_sha256_hash must be a valid SHA256 hash"),
@@ -93,9 +118,14 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			},
 			"password_sha256_hash_wo_version": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Version of the password_sha256_hash_wo field. Bump this value to require a force update of the password on the user.",
+				Description: "Version of the password_sha256_hash_wo field. Bump this value to require a force update of the password on the user. Removing it together with password_sha256_hash_wo in favor of an auth block updates the user in place.",
 				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.RequiresReplace(),
+					int32planmodifier.RequiresReplaceIf(
+						func(ctx context.Context, req planmodifier.Int32Request, resp *int32planmodifier.RequiresReplaceIfFuncResponse) {
+							resp.RequiresReplace = !legacyFieldRemovedForAuth(ctx, req.PlanValue.IsNull(), req.StateValue.IsNull(), req.Config)
+						},
+						legacyReplaceDescription, legacyReplaceDescription,
+					),
 				},
 				Validators: []validator.Int32{
 					int32validator.AlsoRequires(path.MatchRoot("password_sha256_hash_wo")),

--- a/pkg/resource/user/user.md
+++ b/pkg/resource/user/user.md
@@ -43,28 +43,8 @@ Supported method blocks: `no_password`, `plaintext_password`, `sha256_password`,
 `password_sha256_hash` / `password_sha256_hash_wo` (with `password_sha256_hash_wo_version`) are kept
 for backwards compatibility and behave as a single `sha256_hash` method. They compose additively with
 the `auth` block, so existing configurations keep working — but prefer the `auth.sha256_hash` block
-for new ones. Changing a legacy password field replaces the user.
-
-To migrate, replace the legacy fields with an `auth.sha256_hash` block carrying the same hash:
-that plans as an in-place update (the configured methods are re-asserted with `ALTER USER`),
-not a replacement, so grants and dependent resources are untouched.
-
-```terraform
-resource "clickhousedbops_user" "example" {
-  name = "example"
-
-  # Before (deprecated):
-  # password_sha256_hash_wo         = sha256("changeme")
-  # password_sha256_hash_wo_version = 1
-
-  auth {
-    sha256_hash {
-      value_wo         = sha256("changeme")
-      value_wo_version = 1
-    }
-  }
-}
-```
+for new ones. Replacing them with an `auth.sha256_hash` block carrying the same hash updates the
+user in place.
 
 Known limitations:
 

--- a/pkg/resource/user/user.md
+++ b/pkg/resource/user/user.md
@@ -45,6 +45,27 @@ for backwards compatibility and behave as a single `sha256_hash` method. They co
 the `auth` block, so existing configurations keep working — but prefer the `auth.sha256_hash` block
 for new ones. Changing a legacy password field replaces the user.
 
+To migrate, replace the legacy fields with an `auth.sha256_hash` block carrying the same hash:
+that plans as an in-place update (the configured methods are re-asserted with `ALTER USER`),
+not a replacement, so grants and dependent resources are untouched.
+
+```terraform
+resource "clickhousedbops_user" "example" {
+  name = "example"
+
+  # Before (deprecated):
+  # password_sha256_hash_wo         = sha256("changeme")
+  # password_sha256_hash_wo_version = 1
+
+  auth {
+    sha256_hash {
+      value_wo         = sha256("changeme")
+      value_wo_version = 1
+    }
+  }
+}
+```
+
 Known limitations:
 
 - Authentication values cannot be read back from ClickHouse, so external drift of a secret is not

--- a/pkg/resource/user/user_test.go
+++ b/pkg/resource/user/user_test.go
@@ -70,6 +70,26 @@ func TestUser_acceptance(t *testing.T) {
 		}).
 		Build()
 
+	legacyWOMigrationName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	legacyWOMigrationUpdate := resourcebuilder.New(resourceType, resourceName).
+		WithStringAttribute("name", legacyWOMigrationName).
+		WithBlock("auth", func(auth *resourcebuilder.BlockBuilder) {
+			auth.WithBlock("sha256_hash", func(m *resourcebuilder.BlockBuilder) {
+				m.WithFunction("value_wo", "sha256", "changeme").WithIntAttribute("value_wo_version", 1)
+			})
+		}).
+		Build()
+
+	legacyMigrationName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	legacyMigrationUpdate := resourcebuilder.New(resourceType, resourceName).
+		WithStringAttribute("name", legacyMigrationName).
+		WithBlock("auth", func(auth *resourcebuilder.BlockBuilder) {
+			auth.WithBlock("sha256_hash", func(m *resourcebuilder.BlockBuilder) {
+				m.WithFunction("value", "sha256", "changeme")
+			})
+		}).
+		Build()
+
 	sslName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	sslUpdate := resourcebuilder.New(resourceType, resourceName).
 		WithStringAttribute("name", sslName).
@@ -308,6 +328,39 @@ func TestUser_acceptance(t *testing.T) {
 				}).
 				Build(),
 			UpdateResource:        &sslUpdate,
+			UpdateExpectNoReplace: true,
+			ResourceName:          resourceName,
+			ResourceAddress:       fmt.Sprintf("%s.%s", resourceType, resourceName),
+			CheckNotExistsFunc:    checkNotExistsFunc,
+			CheckAttributesFunc:   checkAttributesFunc,
+		},
+		{
+			Name:        "Migrate legacy password_sha256_hash_wo to the auth block in place",
+			ChEnv:       map[string]string{"CONFIGFILE": "config-single.xml"},
+			Protocol:    "native",
+			ClusterName: nil,
+			Resource: resourcebuilder.New(resourceType, resourceName).
+				WithStringAttribute("name", legacyWOMigrationName).
+				WithFunction("password_sha256_hash_wo", "sha256", "changeme").
+				WithIntAttribute("password_sha256_hash_wo_version", 1).
+				Build(),
+			UpdateResource:        &legacyWOMigrationUpdate,
+			UpdateExpectNoReplace: true,
+			ResourceName:          resourceName,
+			ResourceAddress:       fmt.Sprintf("%s.%s", resourceType, resourceName),
+			CheckNotExistsFunc:    checkNotExistsFunc,
+			CheckAttributesFunc:   checkAttributesFunc,
+		},
+		{
+			Name:        "Migrate legacy password_sha256_hash to the auth block in place",
+			ChEnv:       map[string]string{"CONFIGFILE": "config-single.xml"},
+			Protocol:    "native",
+			ClusterName: nil,
+			Resource: resourcebuilder.New(resourceType, resourceName).
+				WithStringAttribute("name", legacyMigrationName).
+				WithFunction("password_sha256_hash", "sha256", "changeme").
+				Build(),
+			UpdateResource:        &legacyMigrationUpdate,
 			UpdateExpectNoReplace: true,
 			ResourceName:          resourceName,
 			ResourceAddress:       fmt.Sprintf("%s.%s", resourceType, resourceName),

--- a/pkg/resource/user/user_test.go
+++ b/pkg/resource/user/user_test.go
@@ -80,16 +80,6 @@ func TestUser_acceptance(t *testing.T) {
 		}).
 		Build()
 
-	legacyMigrationName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	legacyMigrationUpdate := resourcebuilder.New(resourceType, resourceName).
-		WithStringAttribute("name", legacyMigrationName).
-		WithBlock("auth", func(auth *resourcebuilder.BlockBuilder) {
-			auth.WithBlock("sha256_hash", func(m *resourcebuilder.BlockBuilder) {
-				m.WithFunction("value", "sha256", "changeme")
-			})
-		}).
-		Build()
-
 	sslName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	sslUpdate := resourcebuilder.New(resourceType, resourceName).
 		WithStringAttribute("name", sslName).
@@ -345,22 +335,6 @@ func TestUser_acceptance(t *testing.T) {
 				WithIntAttribute("password_sha256_hash_wo_version", 1).
 				Build(),
 			UpdateResource:        &legacyWOMigrationUpdate,
-			UpdateExpectNoReplace: true,
-			ResourceName:          resourceName,
-			ResourceAddress:       fmt.Sprintf("%s.%s", resourceType, resourceName),
-			CheckNotExistsFunc:    checkNotExistsFunc,
-			CheckAttributesFunc:   checkAttributesFunc,
-		},
-		{
-			Name:        "Migrate legacy password_sha256_hash to the auth block in place",
-			ChEnv:       map[string]string{"CONFIGFILE": "config-single.xml"},
-			Protocol:    "native",
-			ClusterName: nil,
-			Resource: resourcebuilder.New(resourceType, resourceName).
-				WithStringAttribute("name", legacyMigrationName).
-				WithFunction("password_sha256_hash", "sha256", "changeme").
-				Build(),
-			UpdateResource:        &legacyMigrationUpdate,
 			UpdateExpectNoReplace: true,
 			ResourceName:          resourceName,
 			ResourceAddress:       fmt.Sprintf("%s.%s", resourceType, resourceName),


### PR DESCRIPTION
Removing `password_sha256_hash` or `password_sha256_hash_wo`/`password_sha256_hash_wo_version` while adding an `auth` block currently plans as destroy-and-recreate, because those attributes carry `RequiresReplace`. That makes the documented migration off the deprecated fields destructive: recreating a user drops its grants in ClickHouse while separate `grant_privilege` resources still believe they exist. On our production config this planned as 100 users to replace, so we couldn't follow the deprecation notice at all.

This PR makes that one transition an in-place update:

- `password_sha256_hash` and `password_sha256_hash_wo_version` switch from `RequiresReplace` to `RequiresReplaceIf`. Replacement is skipped only when the attribute is being removed (state set, plan null) and the configuration declares at least one method in the `auth` block. Every other change keeps the existing replace behavior, including version bumps for rotation.
- No changes needed in Update: it already re-asserts the full configured method set via `ALTER USER ... IDENTIFIED WITH ...`, so the migrated user ends up exactly as configured.
- Docs: the user resource page shows the before/after of the migration.

Tests: two new acceptance cases migrate a user from each legacy field to `auth.sha256_hash` with `UpdateExpectNoReplace: true` (plancheck asserts the plan is an Update, not Replace). Full `TestUser_acceptance` passes locally against the docker compose ClickHouse (16/16).